### PR TITLE
[Issue 11] Add stack_name env var

### DIFF
--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -31,5 +31,6 @@ cd cdk && npm install && npm run cdk:deploy
 - **Tavily API Key**: Set `TAVILY_API_KEY` in `.env` (local) or create SSM parameter `/job-search-agent/tavily-api-key` (AWS)
 - **Email Notifications**: Set `NOTIFICATION_EMAIL` in `.env` before deploy (optional); `SNS_TOPIC_ARN` is auto-set by CDK
 - **Scheduled Searches**: Set `SCHEDULES` in `.env` as a JSON array (optional); creates EventBridge schedules on deploy
+- **Stack Name**: Set `STACK_NAME` in `.env` to deploy multiple stacks to the same account/region (default: `JobSearchAgentStack`)
 - **Settings**: `agent/pyproject.toml` (line length: 100, Python 3.13)
 - **Logging**: `LOG_LEVEL` env var (default: INFO)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -74,6 +74,8 @@ npm install
 npm run cdk:deploy
 ```
 
+To deploy multiple stacks to the same account/region, set `STACK_NAME` in `agent/.env` (default: `JobSearchAgentStack`).
+
 This takes a few minutes. CDK builds a Docker image, pushes it to ECR, and creates an AgentCore Runtime. When it finishes, you'll see outputs like:
 
 ```

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -21,3 +21,6 @@ TAVILY_API_KEY=tvly-YOUR_API_KEY_HERE
 # company (required); title, location, schedule (optional)
 # schedule: any EventBridge expression — cron(...) or rate(...). Defaults to rate(7 days)
 # SCHEDULES=[{"company":"Google","title":"Software Engineer","location":"Remote"},{"company":"Meta","schedule":"rate(14 days)"}]
+
+# Custom CloudFormation stack name (allows multiple deploys to the same account/region)
+# STACK_NAME=JobSearchAgentStack

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -14,6 +14,7 @@ const {
   BEDROCK_MODEL_ID,
   NOTIFICATION_EMAIL,
   SCHEDULES,
+  STACK_NAME,
 } = process.env
 
 const account = CDK_DEFAULT_ACCOUNT ?? AWS_DEFAULT_ACCOUNT_ID
@@ -32,9 +33,11 @@ if (!account || !region) {
   )
 }
 
+const stackName = STACK_NAME ?? 'JobSearchAgentStack'
+
 const app = new App()
-new JobSearchAgentStack(app, 'JobSearchAgentStack', {
-  description: 'Demo template for strands-agents',
+new JobSearchAgentStack(app, stackName, {
+  description: 'Job Search Agent infrastructure',
   bedrockModelID,
   notificationEmail,
   schedules,


### PR DESCRIPTION
Adds STACK_NAME env var so you can deploy multiple stacks to the same account/region without naming collisions. Defaults to JobSearchAgentStack if unset, so nothing changes for existing deploys.

Also fixes the stack description which still said "Demo template for strands-agents". 

fixes #11 