### PR TITLE
[Issue 14] Support multiple notification emails

### DIFF
--- a/.github/workflows/cdk-ci-cd.yml
+++ b/.github/workflows/cdk-ci-cd.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Deploy
         run: npm run cdk:deploy:ci
         env:
-          NOTIFICATION_EMAIL: ${{ vars.NOTIFICATION_EMAIL }}
+          NOTIFICATION_EMAILS: ${{ vars.NOTIFICATION_EMAILS }}
           SCHEDULES: ${{ vars.SCHEDULES }}
           BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
           STACK_NAME: ${{ vars.STACK_NAME }}

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -29,7 +29,7 @@ cd cdk && npm install && npm run cdk:deploy
 
 - **Model**: Set `BEDROCK_MODEL_ID` in `.env` (local) or CDK env vars (deploy)
 - **Tavily API Key**: Set `TAVILY_API_KEY` in `.env` (local) or create SSM parameter `/job-search-agent/tavily-api-key` (AWS)
-- **Email Notifications**: Set `NOTIFICATION_EMAIL` in `.env` before deploy (optional); `SNS_TOPIC_ARN` is auto-set by CDK
+- **Email Notifications**: Set `NOTIFICATION_EMAILS` in `.env` before deploy (comma-separated, optional); `SNS_TOPIC_ARN` is auto-set by CDK
 - **Scheduled Searches**: Set `SCHEDULES` in `.env` as a JSON array (optional); creates EventBridge schedules on deploy
 - **Stack Name**: Set `STACK_NAME` in `.env` to deploy multiple stacks to the same account/region (default: `JobSearchAgentStack`)
 - **Settings**: `agent/pyproject.toml` (line length: 100, Python 3.13)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -50,13 +50,13 @@ Get your API key at [tavily.com](https://tavily.com).
 
 ### 2. Set Up Email Notifications (Optional)
 
-To receive email alerts when companies are hiring, add your email to `agent/.env`:
+To receive email alerts when companies are hiring, add emails to `agent/.env` (comma-separated for multiple):
 
 ```bash
-NOTIFICATION_EMAIL=your-email@example.com
+NOTIFICATION_EMAILS=your-email@example.com,teammate@example.com
 ```
 
-After deploying, you'll receive a confirmation email — click the link to activate notifications.
+After deploying, each address will receive a confirmation email — click the link to activate notifications.
 
 ### 3. Bootstrap and Deploy
 
@@ -186,7 +186,7 @@ Set these as GitHub repository **variables** (Settings > Secrets and variables >
 
 | Variable | Description | Default |
 |---|---|---|
-| `NOTIFICATION_EMAIL` | Email for SNS hiring alerts | _(none)_ |
+| `NOTIFICATION_EMAILS` | Comma-separated emails for SNS hiring alerts | _(none)_ |
 | `SCHEDULES` | JSON array of scheduled searches (see [Scheduled Searches](#set-up-scheduled-searches-optional)) | _(none)_ |
 | `BEDROCK_MODEL_ID` | Bedrock model to use | Stack default |
 | `STACK_NAME` | CloudFormation stack name | `JobSearchAgentStack` |
@@ -212,7 +212,7 @@ Then redeploy:
 cd cdk && npm run cdk:deploy
 ```
 
-The agent sends SNS notifications when it finds open positions, so pair this with `NOTIFICATION_EMAIL` for automated alerts.
+The agent sends SNS notifications when it finds open positions, so pair this with `NOTIFICATION_EMAILS` for automated alerts.
 
 ## Clean Up
 

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -12,7 +12,7 @@ TAVILY_API_KEY=tvly-YOUR_API_KEY_HERE
 # BEDROCK_MODEL_ID=your-preferred-model-id
 
 # Set before CDK deploy to receive email alerts when companies are hiring
-# NOTIFICATION_EMAIL=your-email@example.com
+# NOTIFICATION_EMAILS=your-email@example.com,another@example.com
 
 # Auto-set by CDK. Only needed for local notification testing.
 # SNS_TOPIC_ARN=arn:aws:sns:us-west-2:123456789012:your-topic

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -12,7 +12,7 @@ const {
   CDK_DEFAULT_ACCOUNT,
   CDK_DEFAULT_REGION,
   BEDROCK_MODEL_ID,
-  NOTIFICATION_EMAIL,
+  NOTIFICATION_EMAILS,
   SCHEDULES,
   STACK_NAME,
 } = process.env
@@ -22,8 +22,9 @@ const region = CDK_DEFAULT_REGION ?? AWS_DEFAULT_REGION
 // Use || instead of ?? to treat empty strings (from unset GitHub vars) as undefined
 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 const bedrockModelID = BEDROCK_MODEL_ID || undefined
-// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-const notificationEmail = NOTIFICATION_EMAIL || undefined
+const notificationEmails = NOTIFICATION_EMAILS?.split(',')
+  .map((e) => e.trim())
+  .filter(Boolean)
 const schedules: ScheduleConfig[] | undefined = SCHEDULES
   ? (JSON.parse(SCHEDULES) as ScheduleConfig[])
   : undefined
@@ -43,7 +44,7 @@ const app = new App()
 new JobSearchAgentStack(app, stackName, {
   description: 'Job Search Agent infrastructure',
   bedrockModelID,
-  notificationEmail,
+  notificationEmails,
   schedules,
   env: { account, region },
 })

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -33,7 +33,7 @@ export interface ScheduleConfig {
 
 interface AgentStackProps extends StackProps {
   bedrockModelID?: string | undefined
-  notificationEmail?: string | undefined
+  notificationEmails?: string[] | undefined
   schedules?: ScheduleConfig[] | undefined
 }
 
@@ -123,8 +123,8 @@ export class JobSearchAgentStack extends Stack {
       displayName: 'Job Search Agent Notifications',
     })
 
-    if (props.notificationEmail) {
-      notificationTopic.addSubscription(new EmailSubscription(props.notificationEmail))
+    for (const email of props.notificationEmails ?? []) {
+      notificationTopic.addSubscription(new EmailSubscription(email))
     }
 
     notificationTopic.grantPublish(agentRole)

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -206,23 +206,19 @@ describe('JobSearchAgentStack', () => {
   })
 
   describe('SNS Notifications', () => {
-    it('does not create email subscription when notificationEmail is not provided', () => {
+    it('does not create email subscription when notificationEmails is not provided', () => {
       template.resourceCountIs('AWS::SNS::Subscription', 0)
     })
 
-    it('creates email subscription when notificationEmail is provided', () => {
+    it('creates email subscription for each notificationEmails entry', () => {
       const appWithEmail = new App()
       const stackWithEmail = new JobSearchAgentStack(appWithEmail, 'TestStackWithEmail', {
-        notificationEmail: 'test@example.com',
+        notificationEmails: ['a@example.com', 'b@example.com'],
         env: { account: '123456789012', region: 'us-west-2' },
       })
       const templateWithEmail = Template.fromStack(stackWithEmail)
 
-      templateWithEmail.resourceCountIs('AWS::SNS::Subscription', 1)
-      templateWithEmail.hasResourceProperties('AWS::SNS::Subscription', {
-        Protocol: 'email',
-        Endpoint: 'test@example.com',
-      })
+      templateWithEmail.resourceCountIs('AWS::SNS::Subscription', 2)
     })
   })
 


### PR DESCRIPTION
## Summary
- `NOTIFICATION_EMAILS` replaces `NOTIFICATION_EMAIL` and accepts comma-separated addresses
- Each email gets its own SNS subscription so multiple people can receive hiring alerts

## Changes
- **Stack**: `notificationEmail?: string` → `notificationEmails?: string[]`, loop over array for subscriptions
- **CDK entry**: parse comma-separated env var into array (trim + filter empties)
- **Tests**: verify two emails → two `AWS::SNS::Subscription` resources
- **Config/docs**: renamed env var everywhere (`.env`, `.env.example`, CI workflow, `DEPLOYMENT.md`, `tech.md`)

## Test plan
- [x] `npm test` — all 18 tests pass, snapshot updated
- [x] `npm run check` — lint and types clean
- [ ] Deploy and confirm both emails get SNS confirmation requests

fixes #14 