### PR TITLE
Update docs

### DIFF
--- a/.kiro/steering/product.md
+++ b/.kiro/steering/product.md
@@ -13,7 +13,4 @@ Takes company name as input → returns hiring status, position titles, and job 
 - Single company job search using Tavily web search API
 - Real-time results from live job postings and career pages
 - Optional email notifications via SNS when companies are hiring
-- Strands framework with AgentCore Runtime deployment
-- OpenTelemetry observability and CloudWatch Logs
-- Secure API key management via SSM Parameter Store
 - EventBridge Scheduler for periodic job searches

--- a/.kiro/steering/python-agent.md
+++ b/.kiro/steering/python-agent.md
@@ -14,10 +14,10 @@ fileMatchPattern: "agent/**"
 
 ## Structure
 
-**Main**: `agentcore_app.py` (BedrockAgentCoreApp + @app.entrypoint)
-**Secrets**: `secret_utils.py` (SSM Parameter Store integration for API keys)
-**Tools**: Community tools from `strands_tools` package (`http_request`, `current_time`, `tavily_search`, `use_aws` when SNS is configured)
-**Custom Tools**: Add in `src/tools/` directory when needed
+**Main**: BedrockAgentCoreApp + @app.entrypoint
+**Secrets**: SSM Parameter Store integration
+**Tools**: Community tools from `strands_tools` (`http_request`, `current_time`, `tavily_search`, `use_aws`)
+**Custom Tools**: Add in `src/tools/` directory
 
 ## Agent Patterns
 
@@ -34,12 +34,3 @@ fileMatchPattern: "agent/**"
 
 **Agent**: Test tool availability with `assert "tool_name" in get_agent().tool_names`
 **Functions**: Type hints required, descriptive docstrings
-
-## Environment Variables
-
-**LOG_LEVEL**: INFO (default), DEBUG, ERROR
-**BEDROCK_MODEL_ID**: Override default model (see `DEFAULT_MODEL_ID` in `agentcore_app.py`)
-**AWS_REGION**: Auto-set by AgentCore Runtime
-**TAVILY_API_KEY**: Local dev only - Tavily API key (or use SSM)
-**TAVILY_API_KEY_SSM_PARAMETER**: SSM parameter path (default: `/job-search-agent/tavily-api-key`)
-**SNS_TOPIC_ARN**: Optional - SNS topic ARN for email notifications when companies are hiring

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -9,22 +9,6 @@
 
 See `agent/pyproject.toml` and `cdk/package.json` for current versions.
 
-## Quick Commands
-
-**Agent Setup & Run:**
-
-```bash
-cd agent && python3.13 -m venv .venv && source .venv/bin/activate && pip install -e ".[dev]"
-python src/agentcore_app.py     # Local run
-./quality-check.sh              # All quality checks
-```
-
-**CDK Deploy:**
-
-```bash
-cd cdk && npm install && npm run cdk:deploy
-```
-
 ## Configuration
 
 - **Model**: Set `BEDROCK_MODEL_ID` in `.env` (local) or CDK env vars (deploy)


### PR DESCRIPTION
## Summary

The steering docs in `.kiro/steering/` had a bunch of duplicated info between the always-loaded files (tech.md, structure.md, product.md) and the conditionally-loaded ones (python-agent.md, typescript-cdk.md). When Kiro loads both together you'd see the same stuff twice. This gives each piece of info a single owner.

- **tech.md**: Dropped the "Quick Commands" section — those already live in python-agent.md and typescript-cdk.md
- **python-agent.md**: Removed the "Environment Variables" section (tech.md covers this) and trimmed the "Structure" section to just role labels (structure.md owns file layout)
- **product.md**: Cut implementation details (Strands framework, OpenTelemetry, SSM) from the feature list — kept only user-facing features

No code changes, CLAUDE.md intentionally left alone (it's a self-contained summary).

## Test plan

- [x] `cd agent && ./quality-check.sh` passes
- [x] `cd cdk && npm test && npm run check` passes
- [x] Verified no info was lost, just moved to its single owner
