### PR TITLE
Allow using the Anthropic API in addition to Bedrock

### DIFF
--- a/.github/workflows/cdk-ci-cd.yml
+++ b/.github/workflows/cdk-ci-cd.yml
@@ -90,5 +90,7 @@ jobs:
         env:
           NOTIFICATION_EMAILS: ${{ vars.NOTIFICATION_EMAILS }}
           SCHEDULES: ${{ vars.SCHEDULES }}
+          MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
           BEDROCK_MODEL_ID: ${{ vars.BEDROCK_MODEL_ID }}
+          ANTHROPIC_MODEL_ID: ${{ vars.ANTHROPIC_MODEL_ID }}
           STACK_NAME: ${{ vars.STACK_NAME }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,18 +8,19 @@ Get the job search agent running on AWS in minutes.
 - Docker running locally
 - Node.js 24 and Python 3.14
 - [uv](https://docs.astral.sh/uv/) for Python package management
-- Bedrock model access in your AWS account
+- Anthropic API key (sign up at [console.anthropic.com](https://console.anthropic.com)) — or Bedrock model access in your AWS account when using `MODEL_PROVIDER=bedrock`
 - Tavily API key (sign up at [tavily.com](https://tavily.com) - free tier available)
 
 Check [Amazon Bedrock AgentCore regions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) to make sure AgentCore is available where you want to deploy.
 
 ## Try It Locally First
 
-Always test before deploying. Set up your Tavily API key and start the agent:
+Always test before deploying. Set up your API keys and start the agent:
 
 ```bash
 cd agent
-echo "TAVILY_API_KEY=tvly-xxxxx" > .env  # Add your Tavily API key
+echo "ANTHROPIC_API_KEY=sk-ant-xxxxx" > .env
+echo "TAVILY_API_KEY=tvly-xxxxx" >> .env
 uv sync
 uv run --env-file .env python src/agentcore_app.py
 ```
@@ -34,18 +35,23 @@ curl -X POST http://localhost:8080/invocations \
 
 ## Deploy to AWS
 
-### 1. Store the Tavily API Key
+### 1. Store the API Keys
 
-The agent needs a Tavily API key for web search. Store it in SSM Parameter Store:
+The agent needs an Anthropic API key for the model (default provider) and a Tavily API key for web search. Store both in SSM Parameter Store:
 
 ```bash
+aws ssm put-parameter \
+  --name "/job-search-agent/anthropic-api-key" \
+  --value "sk-ant-xxxxx" \
+  --type SecureString
+
 aws ssm put-parameter \
   --name "/job-search-agent/tavily-api-key" \
   --value "tvly-xxxxx" \
   --type SecureString
 ```
 
-Get your API key at [tavily.com](https://tavily.com).
+Get your keys at [console.anthropic.com](https://console.anthropic.com) and [tavily.com](https://tavily.com). The Anthropic parameter isn't needed if you deploy with `MODEL_PROVIDER=bedrock`.
 
 ### 2. Set Up Email Notifications (Optional)
 
@@ -120,17 +126,19 @@ aws logs describe-log-groups --log-group-name-prefix /aws/bedrock-agentcore/runt
 aws logs tail /aws/bedrock-agentcore/runtimes/JobSearchAgentStack_JobSearchAgent-<id>-DEFAULT --follow
 ```
 
-## Change the Model
+## Change the Model or Provider
 
-Want to use a different Bedrock model? Edit `agent/.env`:
+The agent supports two model providers, selected with `MODEL_PROVIDER` in `agent/.env`:
+
+- **`anthropic`** (default) — calls the Anthropic API directly. Requires the Anthropic API key (SSM parameter above). Override the model with `ANTHROPIC_MODEL_ID` (default: `claude-sonnet-5`); see [Anthropic model IDs](https://docs.claude.com/en/docs/about-claude/models/overview).
+- **`bedrock`** — uses Amazon Bedrock with the runtime's IAM role. Requires Bedrock model access in your account. Override the model with `BEDROCK_MODEL_ID` (default: `us.anthropic.claude-sonnet-4-6`); see [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
 
 ```bash
+MODEL_PROVIDER=bedrock
 BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-6
 ```
 
 Then redeploy: `npm run cdk:deploy`
-
-See [Amazon Bedrock Model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html) for available models.
 
 ## Development Loop
 
@@ -187,7 +195,9 @@ Set these as GitHub repository **variables** (Settings > Secrets and variables >
 |---|---|---|
 | `NOTIFICATION_EMAILS` | Comma-separated emails for SNS hiring alerts | _(none)_ |
 | `SCHEDULES` | JSON array of scheduled searches (see [Scheduled Searches](#set-up-scheduled-searches-optional)) | _(none)_ |
-| `BEDROCK_MODEL_ID` | Bedrock model to use | Stack default |
+| `MODEL_PROVIDER` | Model provider: `anthropic` or `bedrock` | `anthropic` |
+| `ANTHROPIC_MODEL_ID` | Anthropic API model (when provider is `anthropic`) | `claude-sonnet-5` |
+| `BEDROCK_MODEL_ID` | Bedrock model (when provider is `bedrock`) | `us.anthropic.claude-sonnet-4-6` |
 | `STACK_NAME` | CloudFormation stack name | `JobSearchAgentStack` |
 
 ## Set Up Scheduled Searches (Optional)
@@ -233,4 +243,6 @@ This deletes the AgentCore Runtime and IAM roles. Note that CloudWatch logs and 
 
 **Runtime errors**: Check CloudWatch logs. The agent logs every request and tool call.
 
-**Model access**: If you get "model not found" errors, enable the model in the Bedrock console first.
+**Model access (anthropic provider)**: If invocations fail with an SSM `ParameterNotFound` error, create the `/job-search-agent/anthropic-api-key` parameter (see [Store the API Keys](#1-store-the-api-keys)). Authentication errors mean the stored key is invalid.
+
+**Model access (bedrock provider)**: If you get "model not found" or throttling errors, enable the model in the Bedrock console and check your account's Bedrock quotas.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ Built with [Strands Agents](https://strandsagents.com) and deployed to Amazon Be
 ## Quick Start
 
 ```bash
-# Get a Tavily API key (free tier available)
-# Sign up at https://tavily.com
+# Get API keys: Anthropic (https://console.anthropic.com)
+# and Tavily (https://tavily.com, free tier available)
 
 # Run locally
 cd agent
-echo "TAVILY_API_KEY=your_key_here" > .env
+echo "ANTHROPIC_API_KEY=sk-ant-xxxxx" > .env
+echo "TAVILY_API_KEY=tvly-xxxxx" >> .env
 uv sync
 uv run --env-file .env python src/agentcore_app.py
 
@@ -25,7 +26,11 @@ curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
   -d '{"company": "Stripe", "title": "Engineer"}'
 
-# Put Tavily API key in SSM Parameter Store
+# Put API keys in SSM Parameter Store
+aws ssm put-parameter \
+  --name "/job-search-agent/anthropic-api-key" \
+  --value "sk-ant-xxxxx" \
+  --type SecureString
 aws ssm put-parameter \
   --name "/job-search-agent/tavily-api-key" \
   --value "tvly-xxxxx" \

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,15 +1,29 @@
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO
 
+# Model provider: "anthropic" (default) or "bedrock"
+# MODEL_PROVIDER=anthropic
+
+# https://console.anthropic.com — required when MODEL_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-YOUR_API_KEY_HERE
+
+# For AWS deployment, store in SSM instead:
+#   aws ssm put-parameter --name "/job-search-agent/anthropic-api-key" \
+#     --value "sk-ant-YOUR_API_KEY" --type SecureString
+
+# https://docs.claude.com/en/docs/about-claude/models/overview
+# ANTHROPIC_MODEL_ID=claude-sonnet-5
+
+# Used when MODEL_PROVIDER=bedrock
+# https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
+# BEDROCK_MODEL_ID=your-preferred-model-id
+
 # https://app.tavily.com (free tier: 1,000 requests/month)
 TAVILY_API_KEY=tvly-YOUR_API_KEY_HERE
 
 # For AWS deployment, store in SSM instead:
 #   aws ssm put-parameter --name "/job-search-agent/tavily-api-key" \
 #     --value "tvly-YOUR_API_KEY" --type SecureString
-
-# https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html
-# BEDROCK_MODEL_ID=your-preferred-model-id
 
 # Set before CDK deploy to receive email alerts when companies are hiring
 # NOTIFICATION_EMAILS=your-email@example.com,another@example.com

--- a/agent/README.md
+++ b/agent/README.md
@@ -26,12 +26,12 @@ curl -X POST http://localhost:8080/invocations \
 
 ## How It Works
 
-The agent uses community tools from `strands-agents-tools`:
+The agent uses community tools from `strands-agents-tools`, plus one custom tool:
 
 - **tavily_search** - Searches the web for career pages and job listings
 - **http_request** - Fetches specific URLs found by search
 - **current_time** - Timestamps search results
-- **use_aws** - Publishes SNS notifications (conditionally loaded when `SNS_TOPIC_ARN` is set)
+- **send_job_alert** - Custom tool in `src/tools/` that publishes SNS notifications (loaded when `SNS_TOPIC_ARN` is set)
 
 When you send a company name, the agent searches for career pages, fetches the content, and extracts job information.
 
@@ -72,7 +72,7 @@ The quality check script auto-fixes most issues. Run it before committing.
 
 ## Adding Custom Tools
 
-Right now we're using community tools, but you can add custom ones in `src/tools/`:
+Custom tools live in `src/tools/` (see `sns_tools.py`). To add one:
 
 ```python
 from strands import tool

--- a/agent/README.md
+++ b/agent/README.md
@@ -8,8 +8,9 @@ The Python side of the job search agent. This is where the AI magic happens.
 # First time setup
 uv sync
 
-# Add your Tavily API key (get one at tavily.com)
-echo "TAVILY_API_KEY=tvly-xxxxx" > .env
+# Add your API keys (console.anthropic.com and tavily.com)
+echo "ANTHROPIC_API_KEY=sk-ant-xxxxx" > .env
+echo "TAVILY_API_KEY=tvly-xxxxx" >> .env
 
 # Start the agent
 uv run --env-file .env python src/agentcore_app.py
@@ -36,16 +37,15 @@ When you send a company name, the agent searches for career pages, fetches the c
 
 ## Configuration
 
-Copy `.env.example` to `.env` and add your Tavily API key:
+Copy `.env.example` to `.env` and add your API keys:
 
 ```bash
 cp .env.example .env
-# Edit .env and set TAVILY_API_KEY=tvly-xxxxx
 ```
 
-The Tavily API key is required for web search. Get one at [tavily.com](https://tavily.com).
+The Anthropic API key powers the model (or set `MODEL_PROVIDER=bedrock` to use Amazon Bedrock via IAM instead). The Tavily API key is required for web search.
 
-For AWS deployment, the key is stored in SSM Parameter Store instead (see [DEPLOYMENT.md](../DEPLOYMENT.md)).
+For AWS deployment, the keys are stored in SSM Parameter Store instead (see [DEPLOYMENT.md](../DEPLOYMENT.md)).
 
 ## Input Format
 

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
     "ruff~=0.15",
     "mypy~=2.3",
     "black~=26.5",
-    "boto3-stubs[ssm]~=1.43",
+    "boto3-stubs[ssm,sns]~=1.43",
 ]
 
 [tool.uv]

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 description = "A Strands AI agent"
 requires-python = ">=3.14"
 dependencies = [
-    "strands-agents[otel]~=1.48",
+    "strands-agents[otel,anthropic]~=1.48",
     "strands-agents-tools~=0.8",
     "bedrock-agentcore~=1.18",
     "aws-opentelemetry-distro~=0.18",

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -7,10 +7,11 @@ from typing import Any
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
 from strands.models.anthropic import AnthropicModel
-from strands_tools import current_time, http_request, use_aws  # type: ignore[import-untyped]
+from strands_tools import current_time, http_request  # type: ignore[import-untyped]
 from strands_tools.tavily import tavily_search  # type: ignore[import-untyped]
 
 from secret_utils import get_anthropic_api_key, get_tavily_api_key
+from tools import send_job_alert
 
 DEFAULT_MODEL_PROVIDER = "anthropic"
 DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
@@ -101,11 +102,10 @@ RECOGNIZING JOB LISTINGS:
 
 SNS_NOTIFICATION_PROMPT = """
 NOTIFICATION INSTRUCTIONS:
-After completing your response, if **Hiring Status** is Yes, send exactly ONE SNS notification:
-1. Use the use_aws tool with service_name="sns", operation_name="publish"
-2. Parameters: TopicArn="{topic_arn}", Subject="Job Alert: [COMPANY] is hiring!", Message=your full response text
-3. If the notification fails, still return your normal response - notification is best-effort
-4. Do NOT send more than one notification per request - never retry or send duplicate messages
+After completing your response, if **Hiring Status** is Yes, send exactly ONE notification:
+1. Use the send_job_alert tool with subject="Job Alert: [COMPANY] is hiring!" and message=your full response text
+2. If the notification fails, still return your normal response - notification is best-effort
+3. Do NOT send more than one notification per request - never retry or send duplicate messages
 """
 # fmt: on
 
@@ -146,8 +146,8 @@ def get_agent() -> Agent:
     system_prompt = SYSTEM_PROMPT
     sns_topic_arn = os.environ.get("SNS_TOPIC_ARN", "").strip()
     if sns_topic_arn:
-        tools.append(use_aws)
-        system_prompt += SNS_NOTIFICATION_PROMPT.format(topic_arn=sns_topic_arn)
+        tools.append(send_job_alert)
+        system_prompt += SNS_NOTIFICATION_PROMPT
         logging.info(f"SNS notifications enabled for topic: {sns_topic_arn}")
     else:
         logging.info("SNS_TOPIC_ARN not configured, notifications disabled")

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -6,12 +6,16 @@ from typing import Any
 
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
+from strands.models.anthropic import AnthropicModel
 from strands_tools import current_time, http_request, use_aws  # type: ignore[import-untyped]
 from strands_tools.tavily import tavily_search  # type: ignore[import-untyped]
 
-from secret_utils import get_tavily_api_key
+from secret_utils import get_anthropic_api_key, get_tavily_api_key
 
-DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
+DEFAULT_MODEL_PROVIDER = "anthropic"
+DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
+DEFAULT_ANTHROPIC_MODEL_ID = "claude-sonnet-5"
+ANTHROPIC_MAX_TOKENS = 8192
 # Configure logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
@@ -106,16 +110,27 @@ After completing your response, if **Hiring Status** is Yes, send exactly ONE SN
 # fmt: on
 
 
-def get_model_id() -> str:
-    """
-    Get the Bedrock model ID from environment variable or use default.
+def get_model() -> str | AnthropicModel:
+    """Build the model backend selected by MODEL_PROVIDER (default: anthropic)."""
+    provider = os.getenv("MODEL_PROVIDER", DEFAULT_MODEL_PROVIDER).strip().lower()
 
-    Returns:
-        str: The model ID to use for the agent
-    """
-    model_id = os.getenv("BEDROCK_MODEL_ID", DEFAULT_MODEL_ID)
-    logging.info(f"Using Bedrock model: {model_id}")
-    return model_id
+    if provider == "bedrock":
+        model_id = os.getenv("BEDROCK_MODEL_ID", DEFAULT_BEDROCK_MODEL_ID)
+        logging.info(f"Using Bedrock model: {model_id}")
+        return model_id
+
+    if provider == "anthropic":
+        model_id = os.getenv("ANTHROPIC_MODEL_ID", DEFAULT_ANTHROPIC_MODEL_ID)
+        logging.info(f"Using Anthropic API model: {model_id}")
+        return AnthropicModel(
+            client_args={"api_key": get_anthropic_api_key()},
+            model_id=model_id,
+            max_tokens=ANTHROPIC_MAX_TOKENS,
+        )
+
+    raise ValueError(
+        f"Unsupported MODEL_PROVIDER '{provider}'. Supported values: 'bedrock', 'anthropic'."
+    )
 
 
 def get_agent() -> Agent:
@@ -125,7 +140,7 @@ def get_agent() -> Agent:
     tavily_key = get_tavily_api_key()
     os.environ["TAVILY_API_KEY"] = tavily_key
 
-    model_id = get_model_id()
+    model = get_model()
 
     tools: list[object] = [current_time, http_request, tavily_search]
     system_prompt = SYSTEM_PROMPT
@@ -138,7 +153,7 @@ def get_agent() -> Agent:
         logging.info("SNS_TOPIC_ARN not configured, notifications disabled")
 
     return Agent(
-        model=model_id,
+        model=model,
         tools=tools,
         system_prompt=system_prompt,
     )
@@ -192,7 +207,8 @@ async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
         agent = get_agent()
 
         response = agent(prompt)
-        response_text = response.message["content"][0]["text"]
+        # content can lead with thinking blocks; str() joins only the text blocks
+        response_text = str(response)
 
         logging.info(f"Agent response generated (length: {len(response_text)} chars)")
         logging.info(f"Hiring result for {company}: {response_text}")

--- a/agent/src/secret_utils.py
+++ b/agent/src/secret_utils.py
@@ -6,8 +6,9 @@ from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
-# Default SSM parameter name for Tavily API key
+# Default SSM parameter names (must be created manually before deployment)
 DEFAULT_TAVILY_SSM_PARAMETER = "/job-search-agent/tavily-api-key"
+DEFAULT_ANTHROPIC_SSM_PARAMETER = "/job-search-agent/anthropic-api-key"
 
 
 def is_aws_environment() -> bool:
@@ -27,40 +28,48 @@ def is_aws_environment() -> bool:
 
 
 def get_tavily_api_key() -> str:
+    """Retrieve the Tavily API key (env var locally, SSM in AWS)."""
+    return _get_api_key(
+        env_var="TAVILY_API_KEY",
+        ssm_param_env_var="TAVILY_API_KEY_SSM_PARAMETER",
+        default_parameter=DEFAULT_TAVILY_SSM_PARAMETER,
+    )
+
+
+def get_anthropic_api_key() -> str:
+    """Retrieve the Anthropic API key (env var locally, SSM in AWS)."""
+    return _get_api_key(
+        env_var="ANTHROPIC_API_KEY",
+        ssm_param_env_var="ANTHROPIC_API_KEY_SSM_PARAMETER",
+        default_parameter=DEFAULT_ANTHROPIC_SSM_PARAMETER,
+    )
+
+
+def _get_api_key(env_var: str, ssm_param_env_var: str, default_parameter: str) -> str:
     """
-    Retrieve the Tavily API key from the appropriate source.
-
-    - AWS deployment: Fetches from SSM Parameter Store (cached)
-    - Local development: Checks env var first, then falls back to SSM
-
-    Returns:
-        str: The Tavily API key
+    Retrieve an API key: env var first when running locally, SSM in AWS.
 
     Raises:
         ValueError: If the API key cannot be retrieved
     """
     if not is_aws_environment():
-        env_key = os.environ.get("TAVILY_API_KEY")
+        env_key = os.environ.get(env_var)
         if env_key:
-            logger.info("Using TAVILY_API_KEY from environment variable")
+            logger.info(f"Using {env_var} from environment variable")
             return env_key
-        logger.info("TAVILY_API_KEY not in environment, attempting SSM...")
+        logger.info(f"{env_var} not in environment, attempting SSM...")
 
-    return _get_from_ssm()
+    parameter_name = os.environ.get(ssm_param_env_var, default_parameter)
+    return _get_from_ssm(parameter_name)
 
 
-@lru_cache(maxsize=1)
-def _get_from_ssm() -> str:
-    """Fetch the Tavily API key from SSM Parameter Store (cached)."""
+@lru_cache(maxsize=8)
+def _get_from_ssm(parameter_name: str) -> str:
+    """Fetch a secret from SSM Parameter Store (cached per parameter name)."""
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
 
-    parameter_name = os.environ.get(
-        "TAVILY_API_KEY_SSM_PARAMETER",
-        DEFAULT_TAVILY_SSM_PARAMETER,
-    )
-
-    logger.info(f"Fetching Tavily API key from SSM Parameter: {parameter_name}")
+    logger.info(f"Fetching API key from SSM Parameter: {parameter_name}")
 
     try:
         ssm_client = boto3.client("ssm")

--- a/agent/src/tools/__init__.py
+++ b/agent/src/tools/__init__.py
@@ -1,5 +1,5 @@
 """Tools module for the Strands agent."""
 
-# Custom tools can be added here as needed
-# See strands-agent template for examples
-# https://github.com/deeheber/strands-agent-template
+from .sns_tools import send_job_alert
+
+__all__ = ["send_job_alert"]

--- a/agent/src/tools/sns_tools.py
+++ b/agent/src/tools/sns_tools.py
@@ -1,0 +1,32 @@
+"""Custom SNS notification tool."""
+
+import logging
+import os
+
+import boto3
+from strands import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+def send_job_alert(subject: str, message: str) -> str:
+    """
+    Send a job alert notification to the configured SNS topic.
+
+    Args:
+        subject: Short subject line for the notification
+        message: Full notification body text
+
+    Returns:
+        str: Result of the publish attempt
+    """
+    topic_arn = os.environ.get("SNS_TOPIC_ARN", "").strip()
+    if not topic_arn:
+        return "SNS notifications are not configured"
+
+    sns = boto3.client("sns")
+    # SNS rejects subjects over 100 characters
+    sns.publish(TopicArn=topic_arn, Subject=subject[:100], Message=message)
+    logger.info(f"Job alert published to {topic_arn}")
+    return "Notification sent"

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -3,12 +3,25 @@
 import os
 from unittest.mock import patch
 
-from src.agentcore_app import DEFAULT_MODEL_ID, construct_job_search_prompt, get_agent, get_model_id
+import pytest
+from strands.models.anthropic import AnthropicModel
+
+from src.agentcore_app import (
+    ANTHROPIC_MAX_TOKENS,
+    DEFAULT_ANTHROPIC_MODEL_ID,
+    DEFAULT_BEDROCK_MODEL_ID,
+    construct_job_search_prompt,
+    get_agent,
+    get_model,
+)
 
 
 def test_agent_has_tools() -> None:
     """Test agent has expected tools registered."""
-    with patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"):
+    with (
+        patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"),
+        patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
+    ):
         agent = get_agent()
     tool_names = agent.tool_names
     assert "current_time" in tool_names
@@ -16,11 +29,50 @@ def test_agent_has_tools() -> None:
     assert "tavily_search" in tool_names
 
 
-def test_get_model_id_fallback() -> None:
-    """Test get_model_id returns the default when environment variable is not set."""
-    with patch.dict(os.environ, {}, clear=True):
-        model_id = get_model_id()
-        assert model_id == DEFAULT_MODEL_ID
+def test_get_model_default_is_anthropic() -> None:
+    """Test get_model returns an AnthropicModel with defaults when env is unset."""
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
+    ):
+        model = get_model()
+    assert isinstance(model, AnthropicModel)
+    config = model.get_config()
+    assert config["model_id"] == DEFAULT_ANTHROPIC_MODEL_ID
+    assert config["max_tokens"] == ANTHROPIC_MAX_TOKENS
+
+
+def test_get_model_anthropic_model_id_override() -> None:
+    """Test ANTHROPIC_MODEL_ID overrides the default Anthropic model."""
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_MODEL_ID": "claude-opus-5"}, clear=True),
+        patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
+    ):
+        model = get_model()
+    assert isinstance(model, AnthropicModel)
+    assert model.get_config()["model_id"] == "claude-opus-5"
+
+
+def test_get_model_bedrock_provider() -> None:
+    """Test MODEL_PROVIDER=bedrock returns the default Bedrock model ID string."""
+    with patch.dict(os.environ, {"MODEL_PROVIDER": "bedrock"}, clear=True):
+        model = get_model()
+    assert model == DEFAULT_BEDROCK_MODEL_ID
+
+
+def test_get_model_bedrock_model_id_override() -> None:
+    """Test BEDROCK_MODEL_ID overrides the default Bedrock model."""
+    env = {"MODEL_PROVIDER": "bedrock", "BEDROCK_MODEL_ID": "custom-model-id"}
+    with patch.dict(os.environ, env, clear=True):
+        model = get_model()
+    assert model == "custom-model-id"
+
+
+def test_get_model_unknown_provider_raises() -> None:
+    """Test an unsupported MODEL_PROVIDER fails fast with a clear error."""
+    with patch.dict(os.environ, {"MODEL_PROVIDER": "openai"}, clear=True):
+        with pytest.raises(ValueError, match="Unsupported MODEL_PROVIDER"):
+            get_model()
 
 
 def test_system_prompt_contains_filtering_rules() -> None:
@@ -63,6 +115,7 @@ def test_agent_with_sns_has_use_aws_tool() -> None:
     """Test agent includes use_aws tool when SNS_TOPIC_ARN is configured."""
     with (
         patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"),
+        patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
         patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:test-topic"}),
     ):
         agent = get_agent()
@@ -74,6 +127,7 @@ def test_system_prompt_includes_sns_when_configured() -> None:
     topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
     with (
         patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"),
+        patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
         patch.dict(os.environ, {"SNS_TOPIC_ARN": topic_arn}),
     ):
         agent = get_agent()

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -111,19 +111,19 @@ def test_system_prompt_uses_search_approach() -> None:
     assert "https://careers.COMPANY.com" not in SYSTEM_PROMPT
 
 
-def test_agent_with_sns_has_use_aws_tool() -> None:
-    """Test agent includes use_aws tool when SNS_TOPIC_ARN is configured."""
+def test_agent_with_sns_has_send_job_alert_tool() -> None:
+    """Test agent includes send_job_alert tool when SNS_TOPIC_ARN is configured."""
     with (
         patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"),
         patch("src.agentcore_app.get_anthropic_api_key", return_value="mock-anthropic-key"),
         patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:test-topic"}),
     ):
         agent = get_agent()
-    assert "use_aws" in agent.tool_names
+    assert "send_job_alert" in agent.tool_names
 
 
 def test_system_prompt_includes_sns_when_configured() -> None:
-    """Test system prompt contains SNS instructions with topic ARN when configured."""
+    """Test system prompt contains notification instructions when SNS is configured."""
     topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
     with (
         patch("src.agentcore_app.get_tavily_api_key", return_value="mock-api-key"),
@@ -131,6 +131,5 @@ def test_system_prompt_includes_sns_when_configured() -> None:
         patch.dict(os.environ, {"SNS_TOPIC_ARN": topic_arn}),
     ):
         agent = get_agent()
-    assert topic_arn in agent.system_prompt
-    assert "sns" in agent.system_prompt.lower()
-    assert "publish" in agent.system_prompt.lower()
+    assert "send_job_alert" in agent.system_prompt
+    assert "NOTIFICATION INSTRUCTIONS" in agent.system_prompt

--- a/agent/tests/test_secret_utils.py
+++ b/agent/tests/test_secret_utils.py
@@ -5,7 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
-from src.secret_utils import clear_ssm_cache, get_tavily_api_key
+from src.secret_utils import (
+    DEFAULT_ANTHROPIC_SSM_PARAMETER,
+    DEFAULT_TAVILY_SSM_PARAMETER,
+    clear_ssm_cache,
+    get_anthropic_api_key,
+    get_tavily_api_key,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -25,7 +31,7 @@ def test_aws_environment_uses_ssm_directly():
         result = get_tavily_api_key()
 
         assert result == "ssm-key"
-        mock_ssm.assert_called_once()
+        mock_ssm.assert_called_once_with(DEFAULT_TAVILY_SSM_PARAMETER)
 
 
 def test_local_uses_env_var_when_set():
@@ -67,3 +73,55 @@ def test_local_error_when_both_fail():
             get_tavily_api_key()
 
         assert "Parameter not found" in str(exc_info.value)
+
+
+def test_get_anthropic_api_key_local_env_var():
+    """Locally, should use ANTHROPIC_API_KEY env var without calling SSM."""
+    with (
+        patch("src.secret_utils.is_aws_environment", return_value=False),
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "env-anthropic-key"}),
+        patch("src.secret_utils._get_from_ssm") as mock_ssm,
+    ):
+        result = get_anthropic_api_key()
+
+        assert result == "env-anthropic-key"
+        mock_ssm.assert_not_called()
+
+
+def test_get_anthropic_api_key_aws_uses_ssm():
+    """In AWS, should fetch the Anthropic key from its own SSM parameter."""
+    with (
+        patch("src.secret_utils.is_aws_environment", return_value=True),
+        patch("src.secret_utils._get_from_ssm", return_value="ssm-anthropic-key") as mock_ssm,
+    ):
+        result = get_anthropic_api_key()
+
+        assert result == "ssm-anthropic-key"
+        mock_ssm.assert_called_once_with(DEFAULT_ANTHROPIC_SSM_PARAMETER)
+
+
+def test_anthropic_ssm_parameter_env_override():
+    """ANTHROPIC_API_KEY_SSM_PARAMETER should override the default parameter name."""
+    with (
+        patch("src.secret_utils.is_aws_environment", return_value=True),
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY_SSM_PARAMETER": "/custom/param"}),
+        patch("src.secret_utils._get_from_ssm", return_value="ssm-key") as mock_ssm,
+    ):
+        get_anthropic_api_key()
+
+        mock_ssm.assert_called_once_with("/custom/param")
+
+
+def test_ssm_cache_isolated_per_parameter():
+    """Distinct parameter names are cached independently; repeats hit the cache."""
+    from src.secret_utils import _get_from_ssm
+
+    with patch("boto3.client") as mock_boto:
+        mock_boto.return_value.get_parameter.side_effect = lambda **kw: {
+            "Parameter": {"Value": f"value-for-{kw['Name']}"}
+        }
+        assert _get_from_ssm("/param/a") == "value-for-/param/a"
+        assert _get_from_ssm("/param/b") == "value-for-/param/b"
+        assert _get_from_ssm("/param/a") == "value-for-/param/a"
+
+    assert mock_boto.return_value.get_parameter.call_count == 2

--- a/agent/tests/test_tools/test_sns_tools.py
+++ b/agent/tests/test_tools/test_sns_tools.py
@@ -1,0 +1,33 @@
+"""Tests for the SNS notification tool."""
+
+import os
+from unittest.mock import patch
+
+from src.tools.sns_tools import send_job_alert
+
+
+def test_send_job_alert_publishes_to_topic():
+    """Publishes subject and message to the topic from SNS_TOPIC_ARN."""
+    topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
+    with (
+        patch.dict(os.environ, {"SNS_TOPIC_ARN": topic_arn}),
+        patch("src.tools.sns_tools.boto3") as mock_boto3,
+    ):
+        result = send_job_alert(subject="Job Alert: Acme is hiring!", message="details")
+
+    assert result == "Notification sent"
+    mock_boto3.client.return_value.publish.assert_called_once_with(
+        TopicArn=topic_arn, Subject="Job Alert: Acme is hiring!", Message="details"
+    )
+
+
+def test_send_job_alert_without_topic_is_noop():
+    """Returns without publishing when SNS_TOPIC_ARN is not set."""
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("src.tools.sns_tools.boto3") as mock_boto3,
+    ):
+        result = send_job_alert(subject="s", message="m")
+
+    assert result == "SNS notifications are not configured"
+    mock_boto3.client.assert_not_called()

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -352,6 +352,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+sns = [
+    { name = "mypy-boto3-sns" },
+]
 ssm = [
     { name = "mypy-boto3-ssm" },
 ]
@@ -790,7 +793,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
-    { name = "boto3-stubs", extra = ["ssm"] },
+    { name = "boto3-stubs", extra = ["sns", "ssm"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -808,7 +811,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = "~=26.5" },
-    { name = "boto3-stubs", extras = ["ssm"], specifier = "~=1.43" },
+    { name = "boto3-stubs", extras = ["ssm", "sns"], specifier = "~=1.43" },
     { name = "mypy", specifier = "~=2.3" },
     { name = "pytest", specifier = "~=9.1" },
     { name = "ruff", specifier = "~=0.15" },
@@ -1018,6 +1021,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/ab/0dc91d80f3f016634c68d451f294a97320fe903a9b6f90b9e57b3f7f1717/mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654", size = 12146869, upload-time = "2026-07-13T11:29:38.874Z" },
     { url = "https://files.pythonhosted.org/packages/85/b5/4c964d02634ba81f4d1c84838e5c5b18ab06d13ed568960f5d6318495ccc/mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5", size = 10965113, upload-time = "2026-07-13T11:28:07.056Z" },
     { url = "https://files.pythonhosted.org/packages/2c/fa/fdc54fe583ba3cafbcedfb70eeeaf03849f75b1827a07096c7bd996f582d/mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88", size = 2753292, upload-time = "2026-07-13T11:33:18.48Z" },
+]
+
+[[package]]
+name = "mypy-boto3-sns"
+version = "1.43.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/8d/21ec0b76b6097d49635a20b4d6ebc7cc66a5da1421220dac191f1cbd98db/mypy_boto3_sns-1.43.23.tar.gz", hash = "sha256:6f8a19b64c6abf1bd623ad91be7e76ce27f2396da1f1083058921d0de4176ad1", size = 32716, upload-time = "2026-06-04T21:04:42.802Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/60/6d827ba2a569fccd535b72af50966d1d2c34cd02368774c8bf119d46ad51/mypy_boto3_sns-1.43.23-py3-none-any.whl", hash = "sha256:9144245c5fecf865f3fb1b73bbb750d5284ec63c7dbfea9d270d35205eab0aa2", size = 40038, upload-time = "2026-06-04T21:04:40.8Z" },
 ]
 
 [[package]]

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -95,6 +95,25 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.120.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/5c/3331da4fc009d448008a50c78d86cc929e8c937cd1442245ce3f80561c4e/anthropic-0.120.0.tar.gz", hash = "sha256:6ba6007dc9b00365b20f6101a6618f5196ac1ceef81512e4b5cc0e7436d4975d", size = 1008042, upload-time = "2026-07-24T16:32:52.384Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/8a/8522bdf809e1f95f0d9c936540987a3f6afba01d2921a2bf488dedf836a8/anthropic-0.120.0-py3-none-any.whl", hash = "sha256:591bd531563ec7b63a1e138f5c11f14cb94edda99623b349c2ce2ece8e08b8a5", size = 1022602, upload-time = "2026-07-24T16:32:50.506Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -556,6 +575,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -703,6 +731,42 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -719,7 +783,7 @@ dependencies = [
     { name = "aws-opentelemetry-distro" },
     { name = "bedrock-agentcore" },
     { name = "boto3" },
-    { name = "strands-agents", extra = ["otel"] },
+    { name = "strands-agents", extra = ["anthropic", "otel"] },
     { name = "strands-agents-tools" },
 ]
 
@@ -737,7 +801,7 @@ requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "~=0.18" },
     { name = "bedrock-agentcore", specifier = "~=1.18" },
     { name = "boto3", specifier = "~=1.43" },
-    { name = "strands-agents", extras = ["otel"], specifier = "~=1.48" },
+    { name = "strands-agents", extras = ["otel", "anthropic"], specifier = "~=1.48" },
     { name = "strands-agents-tools", specifier = "~=0.8" },
 ]
 
@@ -2436,6 +2500,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2493,6 +2566,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
 otel = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
 ]

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -4,14 +4,21 @@ The TypeScript side that deploys everything to AWS. This creates the AgentCore R
 
 ## Prerequisites
 
-Get a Tavily API key at [tavily.com](https://tavily.com) (free tier available), then store it in SSM Parameter Store before deploying:
+Store your API keys in SSM Parameter Store before deploying: an Anthropic key ([console.anthropic.com](https://console.anthropic.com)) for the model and a Tavily key ([tavily.com](https://tavily.com), free tier available) for web search:
 
 ```bash
+aws ssm put-parameter \
+  --name "/job-search-agent/anthropic-api-key" \
+  --value "sk-ant-xxxxx" \
+  --type SecureString
+
 aws ssm put-parameter \
   --name "/job-search-agent/tavily-api-key" \
   --value "tvly-xxxxx" \
   --type SecureString
 ```
+
+The Anthropic parameter isn't needed when deploying with `MODEL_PROVIDER=bedrock`.
 
 ## Deploy
 
@@ -25,12 +32,12 @@ Takes a few minutes. The stack builds a Docker image from `../agent`, pushes it 
 ## What Gets Created
 
 - **AgentCore Runtime** - Serverless container that runs your agent
-- **IAM Role** - Permissions for Bedrock models, SSM parameter read, KMS decrypt (for SSM), and SNS publish
+- **IAM Role** - Permissions for Bedrock models, SSM parameter reads (Tavily + Anthropic API keys), KMS decrypt (for SSM), and SNS publish
 - **ECR Repository** - Auto-created by the Docker asset to store the agent image
 - **SNS Topic** - Receives hiring notifications; email subscriptions added when `NOTIFICATION_EMAILS` is set
 - **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry
 
-The stack outputs `RuntimeId`, `RuntimeArn`, `TavilyApiKeyParameter`, and `NotificationTopicArn`.
+The stack outputs `RuntimeId`, `RuntimeArn`, `TavilyApiKeyParameter`, `AnthropicApiKeyParameter`, and `NotificationTopicArn`.
 
 ## Development
 
@@ -50,13 +57,13 @@ The stack follows this pattern:
 
 1. **IAM roles** - Set up permissions first
 2. **Core resources** - AgentCore Runtime with Docker build
-3. **Outputs** - Export RuntimeId, RuntimeArn, TavilyApiKeyParameter, and NotificationTopicArn
+3. **Outputs** - Export RuntimeId, RuntimeArn, TavilyApiKeyParameter, AnthropicApiKeyParameter, and NotificationTopicArn
 
 All imports are explicit (no wildcards), and we use TypeScript strict mode.
 
 ## Customization
 
-Want to change the model? Set `BEDROCK_MODEL_ID` in `agent/.env`, then run `npm run cdk:deploy`.
+Want to change the model or provider? Set `MODEL_PROVIDER` (`anthropic` default, or `bedrock`) and optionally `ANTHROPIC_MODEL_ID` / `BEDROCK_MODEL_ID` in `agent/.env`, then run `npm run cdk:deploy`.
 
 ## Next Steps
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -10,7 +10,16 @@ const envSchema = z
     CDK_DEFAULT_REGION: z.string().optional(),
     AWS_DEFAULT_ACCOUNT_ID: z.string().optional(),
     AWS_DEFAULT_REGION: z.string().optional(),
+    MODEL_PROVIDER: z
+      .string()
+      .transform((s) => (s === '' ? undefined : s))
+      .pipe(z.enum(['bedrock', 'anthropic']).optional())
+      .optional(),
     BEDROCK_MODEL_ID: z
+      .string()
+      .transform((s) => (s === '' ? undefined : s))
+      .optional(),
+    ANTHROPIC_MODEL_ID: z
       .string()
       .transform((s) => (s === '' ? undefined : s))
       .optional(),
@@ -41,7 +50,9 @@ const env = envSchema.parse(process.env)
 
 const account = (env.CDK_DEFAULT_ACCOUNT ?? env.AWS_DEFAULT_ACCOUNT_ID)!
 const region = (env.CDK_DEFAULT_REGION ?? env.AWS_DEFAULT_REGION)!
+const modelProvider = env.MODEL_PROVIDER ?? undefined
 const bedrockModelID = env.BEDROCK_MODEL_ID ?? undefined
+const anthropicModelID = env.ANTHROPIC_MODEL_ID ?? undefined
 const notificationEmails = env.NOTIFICATION_EMAILS?.split(',')
   .map((e) => e.trim())
   .filter(Boolean)
@@ -52,7 +63,9 @@ const schedules: ScheduleConfig[] | undefined = env.SCHEDULES
 const app = new App()
 new JobSearchAgentStack(app, env.STACK_NAME, {
   description: 'Job Search Agent infrastructure',
+  modelProvider,
   bedrockModelID,
+  anthropicModelID,
   notificationEmails,
   schedules,
   env: { account, region },

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -15,8 +15,9 @@ import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore'
 import * as path from 'path'
 import { Queue } from 'aws-cdk-lib/aws-sqs'
 
-// SSM parameter name for Tavily API key (must be created manually before deployment)
+// SSM parameter names (must be created manually before deployment)
 const TAVILY_API_KEY_SSM_PARAMETER = '/job-search-agent/tavily-api-key'
+const ANTHROPIC_API_KEY_SSM_PARAMETER = '/job-search-agent/anthropic-api-key'
 
 export interface ScheduleConfig {
   company: string
@@ -26,7 +27,9 @@ export interface ScheduleConfig {
 }
 
 interface AgentStackProps extends StackProps {
+  modelProvider?: 'bedrock' | 'anthropic' | undefined
   bedrockModelID?: string | undefined
+  anthropicModelID?: string | undefined
   notificationEmails?: string[] | undefined
   schedules?: ScheduleConfig[] | undefined
 }
@@ -57,6 +60,7 @@ export class JobSearchAgentStack extends Stack {
         actions: ['ssm:GetParameter'],
         resources: [
           `arn:aws:ssm:${this.region}:${this.account}:parameter${TAVILY_API_KEY_SSM_PARAMETER}`,
+          `arn:aws:ssm:${this.region}:${this.account}:parameter${ANTHROPIC_API_KEY_SSM_PARAMETER}`,
         ],
       })
     )
@@ -101,9 +105,12 @@ export class JobSearchAgentStack extends Stack {
         AWS_REGION: this.region,
         AWS_DEFAULT_REGION: this.region,
         LOG_LEVEL: 'INFO',
+        MODEL_PROVIDER: props.modelProvider ?? 'anthropic',
         TAVILY_API_KEY_SSM_PARAMETER: TAVILY_API_KEY_SSM_PARAMETER,
+        ANTHROPIC_API_KEY_SSM_PARAMETER: ANTHROPIC_API_KEY_SSM_PARAMETER,
         SNS_TOPIC_ARN: notificationTopic.topicArn,
         ...(props.bedrockModelID && { BEDROCK_MODEL_ID: props.bedrockModelID }),
+        ...(props.anthropicModelID && { ANTHROPIC_MODEL_ID: props.anthropicModelID }),
       },
     })
 
@@ -160,6 +167,12 @@ export class JobSearchAgentStack extends Stack {
     new CfnOutput(this, 'TavilyApiKeyParameter', {
       description: 'SSM Parameter name for Tavily API Key (must be created before deployment)',
       value: TAVILY_API_KEY_SSM_PARAMETER,
+    })
+
+    new CfnOutput(this, 'AnthropicApiKeyParameter', {
+      description:
+        'SSM Parameter name for Anthropic API Key (must be created before deployment when MODEL_PROVIDER is anthropic)',
+      value: ANTHROPIC_API_KEY_SSM_PARAMETER,
     })
 
     new CfnOutput(this, 'NotificationTopicArn', {

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -3,6 +3,10 @@
 exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the expected template structure 1`] = `
 {
   "Outputs": {
+    "AnthropicApiKeyParameter": {
+      "Description": "SSM Parameter name for Anthropic API Key (must be created before deployment when MODEL_PROVIDER is anthropic)",
+      "Value": "/job-search-agent/anthropic-api-key",
+    },
     "NotificationTopicArn": {
       "Description": "SNS Topic ARN for job search notifications",
       "Value": {
@@ -77,7 +81,10 @@ exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the ex
             {
               "Action": "ssm:GetParameter",
               "Effect": "Allow",
-              "Resource": "arn:aws:ssm:us-west-2:123456789012:parameter/job-search-agent/tavily-api-key",
+              "Resource": [
+                "arn:aws:ssm:us-west-2:123456789012:parameter/job-search-agent/tavily-api-key",
+                "arn:aws:ssm:us-west-2:123456789012:parameter/job-search-agent/anthropic-api-key",
+              ],
               "Sid": "SSMParameterAccess",
             },
             {
@@ -265,9 +272,11 @@ exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the ex
         "AgentRuntimeName": "TestJobSearchAgentStack_JobSearchAgent",
         "Description": "Job search agent with web search, time, and http_request",
         "EnvironmentVariables": {
+          "ANTHROPIC_API_KEY_SSM_PARAMETER": "/job-search-agent/anthropic-api-key",
           "AWS_DEFAULT_REGION": "us-west-2",
           "AWS_REGION": "us-west-2",
           "LOG_LEVEL": "INFO",
+          "MODEL_PROVIDER": "anthropic",
           "SNS_TOPIC_ARN": {
             "Ref": "JobSearchNotificationTopicA750FAD4",
           },

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -51,9 +51,14 @@ describe('JobSearchAgentStack', () => {
             Match.objectLike({
               Action: 'ssm:GetParameter',
               Effect: 'Allow',
-              Resource: Match.stringLikeRegexp(
-                'arn:aws:ssm:.+:.+:parameter/job-search-agent/tavily-api-key'
-              ),
+              Resource: [
+                Match.stringLikeRegexp(
+                  'arn:aws:ssm:.+:.+:parameter/job-search-agent/tavily-api-key'
+                ),
+                Match.stringLikeRegexp(
+                  'arn:aws:ssm:.+:.+:parameter/job-search-agent/anthropic-api-key'
+                ),
+              ],
             }),
             Match.objectLike({
               Action: 'kms:Decrypt',
@@ -99,10 +104,41 @@ describe('JobSearchAgentStack', () => {
           AWS_REGION: 'us-west-2',
           AWS_DEFAULT_REGION: 'us-west-2',
           LOG_LEVEL: 'INFO',
+          MODEL_PROVIDER: 'anthropic',
+          TAVILY_API_KEY_SSM_PARAMETER: '/job-search-agent/tavily-api-key',
+          ANTHROPIC_API_KEY_SSM_PARAMETER: '/job-search-agent/anthropic-api-key',
           SNS_TOPIC_ARN: {
             Ref: Match.stringLikeRegexp('JobSearchNotificationTopic.*'),
           },
         },
+      })
+    })
+
+    it('does not set model ID env vars by default', () => {
+      template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+        EnvironmentVariables: Match.objectLike({
+          BEDROCK_MODEL_ID: Match.absent(),
+          ANTHROPIC_MODEL_ID: Match.absent(),
+        }),
+      })
+    })
+
+    it('passes model provider and model ID overrides to the runtime', () => {
+      const providerApp = new App()
+      const providerStack = new JobSearchAgentStack(providerApp, 'TestProviderStack', {
+        modelProvider: 'bedrock',
+        bedrockModelID: 'custom-bedrock-model',
+        anthropicModelID: 'claude-opus-5',
+        env: { account: '123456789012', region: 'us-west-2' },
+      })
+      const providerTemplate = Template.fromStack(providerStack)
+
+      providerTemplate.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
+        EnvironmentVariables: Match.objectLike({
+          MODEL_PROVIDER: 'bedrock',
+          BEDROCK_MODEL_ID: 'custom-bedrock-model',
+          ANTHROPIC_MODEL_ID: 'claude-opus-5',
+        }),
       })
     })
 
@@ -119,6 +155,11 @@ describe('JobSearchAgentStack', () => {
         Value: {
           'Fn::GetAtt': [Match.stringLikeRegexp('JobSearchAgentRuntime.*'), 'AgentRuntimeArn'],
         },
+      })
+
+      template.hasOutput('AnthropicApiKeyParameter', {
+        Description: Match.stringLikeRegexp('SSM Parameter name for Anthropic API Key.*'),
+        Value: '/job-search-agent/anthropic-api-key',
       })
 
       template.hasOutput('NotificationTopicArn', {


### PR DESCRIPTION
Closes #34

Adds the Anthropic API as a model provider via Strands' `AnthropicModel`, selected with `MODEL_PROVIDER`. Anthropic is now the default (`claude-sonnet-5`); Bedrock still works via `MODEL_PROVIDER=bedrock`. Each provider keeps its own model ID var, so adding OpenAI later is just another branch.

- API key: `ANTHROPIC_API_KEY` locally, `/job-search-agent/anthropic-api-key` in SSM when deployed — same pattern as the Tavily key
- ⚠️ since the default changed, create the SSM param before redeploying (or set `MODEL_PROVIDER=bedrock`)
- Also fixes response parsing that broke on sonnet-5's thinking blocks (`content[0]["text"]` assumed the first block was text)

Tested both providers locally and deployed to AgentCore.