### PR TITLE
Ack scheduler invokes immediately instead of blocking on the search

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ echo "TAVILY_API_KEY=tvly-xxxxx" >> .env
 uv sync
 uv run --env-file .env python src/agentcore_app.py
 
-# In another terminal window
+# In another terminal window ("sync" waits for the result; omit it for async)
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
-  -d '{"company": "Stripe", "title": "Engineer"}'
+  -d '{"company": "Stripe", "title": "Engineer", "sync": true}'
 
 # Put API keys in SSM Parameter Store
 aws ssm put-parameter \

--- a/agent/README.md
+++ b/agent/README.md
@@ -21,8 +21,10 @@ The agent starts on `localhost:8080`. Test it with:
 ```bash
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
-  -d '{"company": "Stripe", "title": "Engineer"}'
+  -d '{"company": "Stripe", "title": "Engineer", "sync": true}'
 ```
+
+`"sync": true` returns the full result. Without it the agent replies `{"status": "accepted"}` immediately and logs the result when done — the mode scheduled invokes use, since EventBridge Scheduler's call times out after ~30s.
 
 ## How It Works
 

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -1,5 +1,6 @@
 """AgentCore Runtime wrapper for the Strands agent."""
 
+import asyncio
 import logging
 import os
 from typing import Any
@@ -184,29 +185,14 @@ def construct_job_search_prompt(company: str, title: str = "", location: str = "
     return " ".join(prompt_parts)
 
 
-@app.entrypoint
-async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
-    """Main entrypoint for the agent invocation."""
+async def run_job_search(company: str, title: str, location: str) -> dict[str, Any]:
+    """Run the job search and return the result dict."""
     try:
-        if not payload:
-            return {"status": "error", "error": "Payload is required"}
-
-        # Extract parameters from payload
-        company = payload.get("company", "")
-        title = payload.get("title", "")
-        location = payload.get("location", "")
-
-        if not company:
-            return {"status": "error", "error": "Company name is required"}
-
         prompt = construct_job_search_prompt(company, title, location)
-
-        logging.info(f"Payload received: {payload}")
-        logging.info(f"Company: {company}, Title: {title}, Location: {location}")
 
         agent = get_agent()
 
-        response = agent(prompt)
+        response = await agent.invoke_async(prompt)
         # content can lead with thinking blocks; str() joins only the text blocks
         response_text = str(response)
 
@@ -224,8 +210,51 @@ async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
 
     except Exception as e:
         logging.error(f"Error processing request: {e}", exc_info=True)
-        logging.error(f"Payload that caused error: {payload}")
         return {"status": "error", "error": "Internal processing error"}
+
+
+# strong refs: asyncio only weakly references tasks
+_background_tasks: set[asyncio.Task[Any]] = set()
+
+
+async def _tracked_job_search(company: str, title: str, location: str) -> None:
+    """Run the job search as a tracked async task so ping reports HealthyBusy."""
+    task_id = app.add_async_task("job_search")
+    try:
+        await run_job_search(company, title, location)
+    finally:
+        app.complete_async_task(task_id)
+
+
+@app.entrypoint
+async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Main entrypoint for the agent invocation."""
+    if not payload:
+        return {"status": "error", "error": "Payload is required"}
+
+    # Extract parameters from payload
+    company = payload.get("company", "")
+    title = payload.get("title", "")
+    location = payload.get("location", "")
+
+    if not company:
+        return {"status": "error", "error": "Company name is required"}
+
+    logging.info(f"Payload received: {payload}")
+    logging.info(f"Company: {company}, Title: {title}, Location: {location}")
+
+    if payload.get("sync"):
+        return await run_job_search(company, title, location)
+
+    # Respond before EventBridge Scheduler's ~30s call timeout DLQs the invocation
+    task = asyncio.create_task(_tracked_job_search(company, title, location))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+    return {
+        "status": "accepted",
+        "search_criteria": {"company": company, "title": title, "location": location},
+    }
 
 
 if __name__ == "__main__":

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -1,7 +1,9 @@
 """Tests for the agent."""
 
+import asyncio
 import os
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from strands.models.anthropic import AnthropicModel
@@ -10,9 +12,11 @@ from src.agentcore_app import (
     ANTHROPIC_MAX_TOKENS,
     DEFAULT_ANTHROPIC_MODEL_ID,
     DEFAULT_BEDROCK_MODEL_ID,
+    _background_tasks,
     construct_job_search_prompt,
     get_agent,
     get_model,
+    invoke,
 )
 
 
@@ -133,3 +137,36 @@ def test_system_prompt_includes_sns_when_configured() -> None:
         agent = get_agent()
     assert "send_job_alert" in agent.system_prompt
     assert "NOTIFICATION INSTRUCTIONS" in agent.system_prompt
+
+
+def test_invoke_requires_company() -> None:
+    """Test invoke returns an error when company is missing."""
+    result = asyncio.run(invoke({"title": "Engineer"}))
+    assert result == {"status": "error", "error": "Company name is required"}
+
+
+def test_invoke_default_returns_accepted_and_runs_search_in_background() -> None:
+    """Test the default path responds immediately and runs the search as a background task."""
+    mock_search = AsyncMock(return_value={"status": "success"})
+
+    async def scenario() -> dict[str, Any]:
+        with patch("src.agentcore_app.run_job_search", mock_search):
+            result = await invoke({"company": "Stripe", "title": "Engineer"})
+            await asyncio.gather(*_background_tasks)
+        return result
+
+    result = asyncio.run(scenario())
+    assert result["status"] == "accepted"
+    mock_search.assert_awaited_once_with("Stripe", "Engineer", "")
+
+
+def test_invoke_sync_returns_full_result() -> None:
+    """Test the sync flag runs the search inline and returns its result."""
+    full_result = {"status": "success", "response": "**Hiring Status**: Yes"}
+    mock_search = AsyncMock(return_value=full_result)
+
+    with patch("src.agentcore_app.run_job_search", mock_search):
+        result = asyncio.run(invoke({"company": "Stripe", "sync": True}))
+
+    assert result == full_result
+    mock_search.assert_awaited_once_with("Stripe", "", "")

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -145,7 +145,7 @@ export class JobSearchAgentStack extends Stack {
                 resources: [`${runtime.agentRuntimeArn}*`],
               }),
             ],
-            retryAttempts: 0,
+            retryAttempts: 2,
             deadLetterQueue: dlq,
           }),
           timeWindow: TimeWindow.flexible(Duration.hours(2)),


### PR DESCRIPTION
Closes #48

Scheduler's synchronous `invokeAgentRuntime` call times out around 30s, but a search takes 30–75s — so every scheduled invoke DLQ'd even though the agent finished and the emails went out.

The entrypoint now runs the search as a background task and returns `{"status": "accepted"}` immediately, using AgentCore's async task tracking so the runtime stays alive (`HealthyBusy`) mid-search. Pass `"sync": true` to get the full result inline (playground / local curl). Also bumped scheduler `retryAttempts` 0 → 2 since retries can no longer duplicate alerts.

Tested locally; will confirm the DLQ stays quiet after deploy.