### PR TITLE
Fix stale and inaccurate documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@
 
 - **Env vars**: all in `agent/.env` — loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
 - **CDK imports**: explicit only, no wildcards — e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
-- **AgentCore regions**: us-west-2 and us-east-1 (AWS availability constraint — not enforced in code).
+- **AgentCore regions**: not available everywhere; check the [AWS availability page](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) before deploying. CI deploys to us-west-2. Not enforced in code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to the job search agent! This guide 
 - **Docker** (for deployment)
 - **AWS CLI** configured with appropriate permissions
 - **Tavily API key** (sign up at [tavily.com](https://tavily.com) - free tier available)
+- **Anthropic API key** (sign up at [console.anthropic.com](https://console.anthropic.com)), or Bedrock model access in your AWS account when using `MODEL_PROVIDER=bedrock`
 - **Git** for version control
 
 ### Initial Setup
@@ -41,7 +42,7 @@ Thank you for your interest in contributing to the job search agent! This guide 
    ```bash
    cd agent
    cp .env.example .env
-   # Edit .env and add your Tavily API key (get one at tavily.com)
+   # Edit .env and add your Tavily and Anthropic API keys
    ```
 
 ## Development Workflow
@@ -125,7 +126,7 @@ import * as cdk from "aws-cdk-lib";
 
 ### Adding New Job Search Tools
 
-1. **Create tool file** in `agent/src/tools/` (currently empty, using community tools)
+1. **Create tool file** in `agent/src/tools/` (see `sns_tools.py` for an existing example)
 2. **Implement with `@tool` decorator** and proper type hints for job search functionality
 3. **Export in `__init__.py`**
 4. **Add tests** in `agent/tests/test_tools/`
@@ -151,7 +152,7 @@ The agent uses community tools from `strands-agents-tools`:
 - `tavily_search` - For searching the web for career pages and job listings
 - `http_request` - For fetching specific URLs found by search
 - `current_time` - For timestamping search results
-- `use_aws` - For publishing SNS notifications (conditionally loaded when `SNS_TOPIC_ARN` is set)
+- `send_job_alert` - Custom tool in `agent/src/tools/sns_tools.py` that publishes SNS notifications (conditionally loaded when `SNS_TOPIC_ARN` is set)
 
 ### Testing Guidelines
 
@@ -223,19 +224,20 @@ Create a pull request with:
 
 Our GitHub Actions workflows will automatically:
 
-**Python Agent CI (`agent-ci.yml`):**
+**Agent CI (`agent-ci.yml`):**
 
 - Run pytest
 - Type check with mypy
 - Lint with ruff
 - Format check with black
 
-**CDK Infrastructure CI (`cdk-ci-cd.yml`):**
+**CDK CI/CD (`cdk-ci-cd.yml`):**
 
 - Build TypeScript
 - Run Vitest tests
 - Lint with ESLint
 - Format check with Prettier
+- Run `cdk synth`, then deploy to AWS on push to main
 
 All checks must pass before merging.
 
@@ -244,7 +246,7 @@ All checks must pass before merging.
 We use `strands-agents-tools` for common functionality:
 
 ```python
-from strands_tools import current_time, http_request, use_aws
+from strands_tools import current_time, http_request
 from strands_tools.tavily import tavily_search
 ```
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,12 +25,12 @@ uv sync
 uv run --env-file .env python src/agentcore_app.py
 ```
 
-In another terminal, send a test request:
+In another terminal, send a test request (`"sync": true` waits for the result; omit it for async):
 
 ```bash
 curl -X POST http://localhost:8080/invocations \
   -H "Content-Type: application/json" \
-  -d '{"company": "Stripe", "title": "Engineer"}'
+  -d '{"company": "Stripe", "title": "Engineer", "sync": true}'
 ```
 
 ## Deploy to AWS
@@ -84,7 +84,7 @@ To deploy multiple stacks to the same account/region, set `STACK_NAME` in `agent
 This takes a few minutes. CDK builds a Docker image, pushes it to ECR, and creates an AgentCore Runtime. When it finishes, you'll see outputs like:
 
 ```
-JobSearchAgentStack.RuntimeId = job-search-agent-abc123
+JobSearchAgentStack.RuntimeId = JobSearchAgentStack_JobSearchAgent-abc123def4
 JobSearchAgentStack.RuntimeArn = arn:aws:bedrock-agentcore:...
 ```
 
@@ -100,7 +100,7 @@ RUNTIME_ARN="arn:aws:bedrock-agentcore:us-west-2:123456789012:agent-runtime/..."
 aws bedrock-agentcore invoke-agent-runtime \
   --agent-runtime-arn $RUNTIME_ARN \
   --qualifier DEFAULT \
-  --payload $(echo '{"company": "Netflix", "title": "Data Scientist"}' | base64) \
+  --payload $(echo '{"company": "Netflix", "title": "Data Scientist", "sync": true}' | base64) \
   response.json
 
 cat response.json
@@ -108,11 +108,11 @@ cat response.json
 
 Or use the AWS Console: Bedrock AgentCore → Runtimes → `JobSearchAgentStack_JobSearchAgent` → Test tab.
 
-Try these payloads:
+Try these payloads (keep `"sync": true` to see the result in the response; without it the agent returns `{"status": "accepted"}` and logs the result instead):
 
-- `{"company": "Stripe"}`
-- `{"company": "Netflix", "title": "Engineer", "location": "remote"}`
-- `{"company": "Panic Inc.", "title": "Software Engineer"}`
+- `{"company": "Stripe", "sync": true}`
+- `{"company": "Netflix", "title": "Engineer", "location": "remote", "sync": true}`
+- `{"company": "Panic Inc.", "title": "Software Engineer", "sync": true}`
 
 ## Check the Logs
 
@@ -147,11 +147,11 @@ Then redeploy: `npm run cdk:deploy`
 3. Test locally: `uv run --env-file .env python src/agentcore_app.py`
 4. Deploy: `cd cdk && npm run cdk:deploy`
 
-The quality check runs mypy, ruff, black, and pytest. It'll catch most problems before deployment.
+The quality check runs pytest, mypy, ruff, and black. It'll catch most problems before deployment.
 
 ## Add Custom Tools
 
-The agent uses community tools (`tavily_search`, `http_request`, `current_time`). To add your own:
+The agent uses community tools (`tavily_search`, `http_request`, `current_time`) plus a custom `send_job_alert` tool in `agent/src/tools/`. To add your own:
 
 ```python
 # agent/src/tools/job_search_tools.py

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That's it. The agent fetches live job postings, extracts titles and links, and r
 - Returns hiring status with position details
 - Optionally sends email alerts via SNS when companies are hiring
 - Scheduled searches via EventBridge for automated monitoring
-- Tracks when jobs were posted
+- Timestamps each search so you know how fresh the results are
 
 **Example:** `{"company": "Stripe", "title": "Engineer"}` → List of engineering roles at Stripe with application links.
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -66,7 +66,7 @@ The agent returns hiring status, position titles, and application links.
 ## Development Workflow
 
 ```bash
-./quality-check.sh    # Run all checks (mypy, ruff, black, pytest)
+./quality-check.sh    # Run all checks (pytest, mypy, ruff, black)
 uv run pytest         # Just the tests
 ```
 

--- a/agent/src/secret_utils.py
+++ b/agent/src/secret_utils.py
@@ -6,7 +6,8 @@ from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
-# Default SSM parameter names (must be created manually before deployment)
+# Default SSM parameter names (created out-of-band, never by the CDK stack;
+# they must exist by the time the agent is invoked)
 DEFAULT_TAVILY_SSM_PARAMETER = "/job-search-agent/tavily-api-key"
 DEFAULT_ANTHROPIC_SSM_PARAMETER = "/job-search-agent/anthropic-api-key"
 

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -33,7 +33,7 @@ Takes a few minutes. The stack builds a Docker image from `../agent`, pushes it 
 
 - **AgentCore Runtime** - Serverless container that runs your agent
 - **IAM Role** - Permissions for Bedrock models, SSM parameter reads (Tavily + Anthropic API keys), KMS decrypt (for SSM), and SNS publish
-- **ECR Repository** - Auto-created by the Docker asset to store the agent image
+- **ECR Image** - The agent image is pushed to the shared ECR repository that `cdk bootstrap` manages (the stack doesn't create its own repository)
 - **SNS Topic** - Receives hiring notifications; email subscriptions added when `NOTIFICATION_EMAILS` is set
 - **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry
 

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -15,7 +15,8 @@ import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore'
 import * as path from 'path'
 import { Queue } from 'aws-cdk-lib/aws-sqs'
 
-// SSM parameter names (must be created manually before deployment)
+// SSM parameter names, created out-of-band (never by this stack); read by the agent at
+// invocation time (the Anthropic one only when MODEL_PROVIDER=anthropic)
 const TAVILY_API_KEY_SSM_PARAMETER = '/job-search-agent/tavily-api-key'
 const ANTHROPIC_API_KEY_SSM_PARAMETER = '/job-search-agent/anthropic-api-key'
 


### PR DESCRIPTION
Did a pass over all the docs to make sure they match the current code. Fixes:

- CONTRIBUTING.md still referenced the `use_aws` community tool and called the tools directory empty. Both predate the custom `send_job_alert` tool. Also added the Anthropic API key to the setup steps (the default provider needs it) and corrected the CI workflow names.
- DEPLOYMENT.md's test commands were missing `"sync": true`, so following them returned `{"status": "accepted"}` instead of actual results. Also fixed the `RuntimeId` example output to match the real naming.
- cdk/README claimed the stack creates an ECR repository; the image actually goes to the CDK bootstrap repo.
- CLAUDE.md's AgentCore region list was outdated, now links to the AWS availability page instead.
- Assorted small fixes: quality-check tool order, the "tracks when jobs were posted" claim in the README, and two code comments that said the SSM parameters must exist before deployment (they're needed at invocation time).

Docs only, no behavior changes. Quality checks and CDK tests pass.