### PR TITLE
Repo cleanup

### DIFF
--- a/.github/workflows/agent-ci.yml
+++ b/.github/workflows/agent-ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cdk-ci-cd.yml
+++ b/.github/workflows/cdk-ci-cd.yml
@@ -13,7 +13,6 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ cdk.out/
 
 # CDK
 cdk/**/*.js
-!cdk/jest.config.js
 cdk/**/*.d.ts
 cdk/.cdk.staging
 cdk/coverage/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Job Search Agent
 
-Thank you for your interest in contributing to the job search agent! This guide will help you get started with development and ensure your contributions align with our project standards.
+How to set up a development environment and get changes merged.
 
 ## Getting Started
 
@@ -13,7 +13,6 @@ Thank you for your interest in contributing to the job search agent! This guide 
 - **AWS CLI** configured with appropriate permissions
 - **Tavily API key** (sign up at [tavily.com](https://tavily.com) - free tier available)
 - **Anthropic API key** (sign up at [console.anthropic.com](https://console.anthropic.com)), or Bedrock model access in your AWS account when using `MODEL_PROVIDER=bedrock`
-- **Git** for version control
 
 ### Initial Setup
 
@@ -34,13 +33,13 @@ Thank you for your interest in contributing to the job search agent! This guide 
 3. **Set up the CDK environment**
 
    ```bash
-   cd cdk
+   cd ../cdk
    npm install
    ```
 
 4. **Configure environment variables**
    ```bash
-   cd agent
+   cd ../agent
    cp .env.example .env
    # Edit .env and add your Tavily and Anthropic API keys
    ```
@@ -159,8 +158,8 @@ The agent uses community tools from `strands-agents-tools`, plus one custom tool
 **Python tests:**
 
 - Mirror source structure in `tests/` directory
-- Use pytest fixtures and parametrize for comprehensive coverage
 - Test both success and error cases
+- Test this project's logic, not framework behavior — skip tests that only restate constants or assert things the language/CDK guarantees
 
 **CDK tests:**
 
@@ -200,13 +199,7 @@ npm run build && npm test && npm run lint
 
 ### 4. Commit Your Changes
 
-Use conventional commit messages:
-
-```bash
-git commit -m "feat: add new custom tool for data processing"
-git commit -m "fix: resolve memory leak in agent execution"
-git commit -m "docs: update deployment instructions"
-```
+Write commit messages as short plain sentences describing the change, e.g. "Add async invoke path for eventbridge universal target".
 
 ### 5. Push and Create Pull Request
 
@@ -266,5 +259,3 @@ When adding tools, consider if they should be:
 - Focus on constructive feedback
 - Help others learn and grow
 - Follow our coding standards consistently
-
-Thank you for contributing to make this template better for everyone!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ npm run cdk:deploy   # Deploy to AWS
 - **Line length**: 100 characters
 - **Formatter**: Black
 - **Linter**: Ruff with auto-fix enabled
-- **Type checker**: mypy in strict mode
+- **Type checker**: mypy in strict mode (`src/`)
 - **Testing**: pytest
 
 ### TypeScript Code Style
@@ -115,11 +115,11 @@ npm run cdk:deploy   # Deploy to AWS
 
 ```typescript
 // ✅ Good
-import { Stack, StackProps } from "aws-cdk-lib";
-import { Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Stack, StackProps, CfnOutput, Duration } from 'aws-cdk-lib'
+import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore'
 
 // ❌ Avoid
-import * as cdk from "aws-cdk-lib";
+import * as cdk from 'aws-cdk-lib'
 ```
 
 ## Project Structure
@@ -147,7 +147,7 @@ def search_job_board(company_name: str, position_type: str) -> dict:
 
 ### Current Tool Usage
 
-The agent uses community tools from `strands-agents-tools`:
+The agent uses community tools from `strands-agents-tools`, plus one custom tool:
 
 - `tavily_search` - For searching the web for career pages and job listings
 - `tavily_extract` - For fetching page content from URLs found by search

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,8 +257,7 @@ When adding tools, consider if they should be:
 
 ## Getting Help
 
-- **Issues**: Create GitHub issues for bugs or feature requests
-- **Discussions**: Use GitHub Discussions for questions and ideas
+- **Issues**: Create GitHub issues for bugs, feature requests, or questions
 - **Documentation**: Check README.md and DEPLOYMENT.md for guidance
 
 ## Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ def search_job_board(company_name: str, position_type: str) -> dict:
 The agent uses community tools from `strands-agents-tools`:
 
 - `tavily_search` - For searching the web for career pages and job listings
-- `http_request` - For fetching specific URLs found by search
+- `tavily_extract` - For fetching page content from URLs found by search
 - `current_time` - For timestamping search results
 - `send_job_alert` - Custom tool in `agent/src/tools/sns_tools.py` that publishes SNS notifications (conditionally loaded when `SNS_TOPIC_ARN` is set)
 
@@ -246,8 +246,8 @@ All checks must pass before merging.
 We use `strands-agents-tools` for common functionality:
 
 ```python
-from strands_tools import current_time, http_request
-from strands_tools.tavily import tavily_search
+from strands_tools import current_time
+from strands_tools.tavily import tavily_extract, tavily_search
 ```
 
 When adding tools, consider if they should be:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -168,14 +168,17 @@ Export it in `agent/src/tools/__init__.py`:
 
 ```python
 from .job_search_tools import parse_greenhouse_api
-__all__ = ["parse_greenhouse_api"]
+from .sns_tools import send_failure_alert, send_job_alert
+
+__all__ = ["parse_greenhouse_api", "send_failure_alert", "send_job_alert"]
 ```
 
-Add to the agent in `agentcore_app.py`:
+Add it to the tool list in `get_agent()` in `agentcore_app.py`:
 
 ```python
 from tools import parse_greenhouse_api
-agent = Agent(tools=[current_time, tavily_search, tavily_extract, parse_greenhouse_api])
+
+tools: list[object] = [current_time, tavily_search, tavily_extract, parse_greenhouse_api]
 ```
 
 ## CI/CD with GitHub Actions
@@ -222,6 +225,8 @@ cd cdk && npm run cdk:deploy
 ```
 
 The agent sends SNS notifications when it finds open positions, so pair this with `NOTIFICATION_EMAILS` for automated alerts.
+
+Scheduled invokes are async — the runtime acks immediately (EventBridge Scheduler's call times out after ~30s) and results arrive via SNS email or CloudWatch logs. Failed invokes land in an SQS dead-letter queue that alarms to the same SNS topic; failures inside the agent send their own SNS alert. To spread load, each schedule fires within a 2-hour window after its scheduled time, not at the exact minute.
 
 ## Clean Up
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -124,11 +124,11 @@ aws logs tail /aws/bedrock-agentcore/runtimes/JobSearchAgentStack_JobSearchAgent
 The agent supports two model providers, selected with `MODEL_PROVIDER` in `agent/.env`:
 
 - **`anthropic`** (default) — calls the Anthropic API directly. Requires the Anthropic API key (SSM parameter above). Override the model with `ANTHROPIC_MODEL_ID` (default: `claude-sonnet-5`); see [Anthropic model IDs](https://docs.claude.com/en/docs/about-claude/models/overview).
-- **`bedrock`** — uses Amazon Bedrock with the runtime's IAM role. Requires Bedrock model access in your account. Override the model with `BEDROCK_MODEL_ID` (default: `us.anthropic.claude-sonnet-4-6`); see [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
+- **`bedrock`** — uses Amazon Bedrock with the runtime's IAM role. Requires Bedrock model access in your account. Override the model with `BEDROCK_MODEL_ID` (default: `us.anthropic.claude-sonnet-5`); see [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
 
 ```bash
 MODEL_PROVIDER=bedrock
-BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-6
+BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-5
 ```
 
 Then redeploy: `npm run cdk:deploy`
@@ -193,7 +193,7 @@ Set these as GitHub repository **variables** (Settings > Secrets and variables >
 | `SCHEDULES` | JSON array of scheduled searches (see [Scheduled Searches](#set-up-scheduled-searches-optional)) | _(none)_ |
 | `MODEL_PROVIDER` | Model provider: `anthropic` or `bedrock` | `anthropic` |
 | `ANTHROPIC_MODEL_ID` | Anthropic API model (when provider is `anthropic`) | `claude-sonnet-5` |
-| `BEDROCK_MODEL_ID` | Bedrock model (when provider is `bedrock`) | `us.anthropic.claude-sonnet-4-6` |
+| `BEDROCK_MODEL_ID` | Bedrock model (when provider is `bedrock`) | `us.anthropic.claude-sonnet-5` |
 | `STACK_NAME` | CloudFormation stack name | `JobSearchAgentStack` |
 
 ## Set Up Scheduled Searches (Optional)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -151,7 +151,7 @@ The quality check runs pytest, mypy, ruff, and black. It'll catch most problems 
 
 ## Add Custom Tools
 
-The agent uses community tools (`tavily_search`, `http_request`, `current_time`) plus a custom `send_job_alert` tool in `agent/src/tools/`. To add your own:
+The agent uses community tools (`tavily_search`, `tavily_extract`, `current_time`) plus a custom `send_job_alert` tool in `agent/src/tools/`. To add your own:
 
 ```python
 # agent/src/tools/job_search_tools.py
@@ -175,7 +175,7 @@ Add to the agent in `agentcore_app.py`:
 
 ```python
 from tools import parse_greenhouse_api
-agent = Agent(tools=[current_time, http_request, tavily_search, parse_greenhouse_api])
+agent = Agent(tools=[current_time, tavily_search, tavily_extract, parse_greenhouse_api])
 ```
 
 ## CI/CD with GitHub Actions

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -65,17 +65,10 @@ After deploying, each address will receive a confirmation email — click the li
 
 ### 3. Bootstrap and Deploy
 
-First time only, bootstrap CDK:
-
 ```bash
 cd cdk
-cdk bootstrap
-```
-
-Then deploy:
-
-```bash
 npm install
+npx cdk bootstrap   # first deploy in this account/region only
 npm run cdk:deploy
 ```
 
@@ -246,7 +239,7 @@ This deletes the AgentCore Runtime and IAM roles. Note that CloudWatch logs and 
 
 **Build failures**: Check the CDK output. Usually it's a missing dependency in `agent/pyproject.toml`.
 
-**Runtime errors**: Check CloudWatch logs. The agent logs every request and tool call.
+**Runtime errors**: Check CloudWatch logs (see [Check the Logs](#check-the-logs)).
 
 **Model access (anthropic provider)**: If invocations fail with an SSM `ParameterNotFound` error, create the `/job-search-agent/anthropic-api-key` parameter (see [Store the API Keys](#1-store-the-api-keys)). Authentication errors mean the stored key is invalid.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Danielle Heberling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> **Note:** This project was started before my current employment as a learning exercise. I'm completing it to finish what I started, not as an indication of active job searching.
-
 # Job Search Agent
 
 [![Awesome Strands Agents](https://img.shields.io/badge/Awesome-Strands%20Agents-00FF77?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjkwIiBoZWlnaHQ9IjQ2MyIgdmlld0JveD0iMCAwIDI5MCA0NjMiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxwYXRoIGQ9Ik05Ny4yOTAyIDUyLjc4ODRDODUuMDY3NCA0OS4xNjY3IDcyLjIyMzQgNTYuMTM4OSA2OC42MDE3IDY4LjM2MTZDNjQuOTgwMSA4MC41ODQzIDcxLjk1MjQgOTMuNDI4MyA4NC4xNzQ5IDk3LjA1MDFMMjM1LjExNyAxMzkuNzc1QzI0NS4yMjMgMTQyLjc2OSAyNDYuMzU3IDE1Ni42MjggMjM2Ljg3NCAxNjEuMjI2TDMyLjU0NiAyNjAuMjkxQy0xNC45NDM5IDI4My4zMTYgLTkuMTYxMDcgMzUyLjc0IDQxLjQ4MzUgMzY3LjU5MUwxODkuNTUxIDQxMS4wMDlMMTkwLjEyNSA0MTEuMTY5QzIwMi4xODMgNDE0LjM3NiAyMTQuNjY1IDQwNy4zOTYgMjE4LjE5NiAzOTUuMzU1QzIyMS43ODQgMzgzLjEyMiAyMTQuNzc0IDM3MC4yOTYgMjAyLjU0MSAzNjYuNzA5TDU0LjQ3MzggMzIzLjI5MUM0NC4zNDQ3IDMyMC4zMjEgNDMuMTg3OSAzMDYuNDM2IDUyLjY4NTcgMzAxLjgzMUwyNTcuMDE0IDIwMi43NjZDMzA0LjQzMiAxNzkuNzc2IDI5OC43NTggMTEwLjQ4MyAyNDguMjMzIDk1LjUxMkw5Ny4yOTAyIDUyLjc4ODRaIiBmaWxsPSIjRkZGRkZGIi8+CjxwYXRoIGQ9Ik0yNTkuMTQ3IDAuOTgxODEyQzI3MS4zODkgLTIuNTc0OTggMjg0LjE5NyA0LjQ2NTcxIDI4Ny43NTQgMTYuNzA3NEMyOTEuMzExIDI4Ljk0OTIgMjg0LjI3IDQxLjc1NyAyNzIuMDI4IDQ1LjMxMzhMNzEuMTcyNyAxMDMuNjcxQzQwLjcxNDIgMTEyLjUyMSAzNy4xOTc2IDE1NC4yNjIgNjUuNzQ1OSAxNjguMDgzTDI0MS4zNDMgMjUzLjA5M0MzMDcuODcyIDI4NS4zMDIgMjk5Ljc5NCAzODIuNTQ2IDIyOC44NjIgNDAzLjMzNkwzMC40MDQxIDQ2MS41MDJDMTguMTcwNyA0NjUuMDg4IDUuMzQ3MDggNDU4LjA3OCAxLjc2MTUzIDQ0NS44NDRDLTEuODIzOSA0MzMuNjExIDUuMTg2MzcgNDIwLjc4NyAxNy40MTk3IDQxNy4yMDJMMjE1Ljg3OCAzNTkuMDM1QzI0Ni4yNzcgMzUwLjEyNSAyNDkuNzM5IDMwOC40NDkgMjIxLjIyNiAyOTQuNjQ1TDQ1LjYyOTcgMjA5LjYzNUMtMjAuOTgzNCAxNzcuMzg2IC0xMi43NzcyIDc5Ljk4OTMgNTguMjkyOCA1OS4zNDAyTDI1OS4xNDcgMC45ODE4MTJaIiBmaWxsPSIjRkZGRkZGIi8+Cjwvc3ZnPgo=&logoColor=white)](https://github.com/cagataycali/awesome-strands-agents)
@@ -8,7 +6,11 @@ AI agent that tells you who's hiring. Give it a company name, get back open posi
 
 Built with [Strands Agents](https://strandsagents.com) and deployed to Amazon Bedrock AgentCore Runtime. Uses [Tavily](https://www.tavily.com/) web search to find career pages and job boards.
 
+> **Note:** This project was started before my current employment as a learning exercise. I'm completing it to finish what I started, not as an indication of active job searching.
+
 ## Quick Start
+
+Prerequisites: [uv](https://docs.astral.sh/uv/) 0.11, Python 3.14, Node 24, Docker, and AWS CLI credentials — see [DEPLOYMENT.md](DEPLOYMENT.md). Running locally only needs uv and the API keys.
 
 ```bash
 # Get API keys: Anthropic (https://console.anthropic.com)
@@ -36,8 +38,10 @@ aws ssm put-parameter \
   --value "tvly-xxxxx" \
   --type SecureString
 
-# Deploy to AWS
-cd cdk && npm run cdk:deploy
+# Deploy to AWS (first deploy in an account/region: npx cdk bootstrap)
+cd ../cdk
+npm install
+npm run cdk:deploy
 ```
 
 That's it. The agent fetches live job postings, extracts titles and links, and returns structured results.
@@ -52,6 +56,19 @@ That's it. The agent fetches live job postings, extracts titles and links, and r
 - Timestamps each search so you know how fresh the results are
 
 **Example:** `{"company": "Stripe", "title": "Engineer"}` → List of engineering roles at Stripe with application links.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Scheduler[EventBridge Scheduler] -->|async invoke| Runtime[AgentCore Runtime<br/>Strands agent]
+    Scheduler -.->|failed invokes| DLQ[SQS dead-letter queue]
+    Runtime -->|search + extract| Tavily[Tavily API]
+    Runtime -->|inference| Model[Anthropic API or Bedrock]
+    Runtime -->|job alerts + failure alerts| Topic[SNS topic]
+    DLQ -.->|CloudWatch alarm| Topic
+    Topic -->|email| You([You])
+```
 
 ## Project Structure
 

--- a/agent/.env.example
+++ b/agent/.env.example
@@ -1,4 +1,4 @@
-# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL — local runs only; the deployed runtime pins INFO
 LOG_LEVEL=INFO
 
 # Model provider: "anthropic" (default) or "bedrock"

--- a/agent/README.md
+++ b/agent/README.md
@@ -31,11 +31,11 @@ curl -X POST http://localhost:8080/invocations \
 The agent uses community tools from `strands-agents-tools`, plus one custom tool:
 
 - **tavily_search** - Searches the web for career pages and job listings
-- **http_request** - Fetches specific URLs found by search
+- **tavily_extract** - Fetches page content from URLs found by search
 - **current_time** - Timestamps search results
 - **send_job_alert** - Custom tool in `src/tools/` that publishes SNS notifications (loaded when `SNS_TOPIC_ARN` is set)
 
-When you send a company name, the agent searches for career pages, fetches the content, and extracts job information.
+When you send a company name, the agent searches for career pages, fetches the content, and extracts job information. Pages are fetched server-side by Tavily, so the runtime never makes arbitrary outbound requests.
 
 ## Configuration
 

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -17,15 +17,16 @@ from tools import send_failure_alert, send_job_alert
 DEFAULT_MODEL_PROVIDER = "anthropic"
 DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
 DEFAULT_ANTHROPIC_MODEL_ID = "claude-sonnet-5"
-ANTHROPIC_MAX_TOKENS = 8192
+ANTHROPIC_MAX_TOKENS = 16000
 JOB_SEARCH_TIMEOUT_SECONDS = 900
 # Configure logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
-    level=getattr(logging, log_level),
+    level=getattr(logging, log_level, logging.INFO),
     format="%(levelname)s | %(name)s | %(message)s",
 )
 logging.getLogger("strands").setLevel(log_level)
+logger = logging.getLogger(__name__)
 
 app = BedrockAgentCoreApp()
 
@@ -118,12 +119,12 @@ def get_model() -> str | AnthropicModel:
 
     if provider == "bedrock":
         model_id = os.getenv("BEDROCK_MODEL_ID", DEFAULT_BEDROCK_MODEL_ID)
-        logging.info(f"Using Bedrock model: {model_id}")
+        logger.info(f"Using Bedrock model: {model_id}")
         return model_id
 
     if provider == "anthropic":
         model_id = os.getenv("ANTHROPIC_MODEL_ID", DEFAULT_ANTHROPIC_MODEL_ID)
-        logging.info(f"Using Anthropic API model: {model_id}")
+        logger.info(f"Using Anthropic API model: {model_id}")
         return AnthropicModel(
             client_args={"api_key": get_anthropic_api_key()},
             model_id=model_id,
@@ -150,9 +151,9 @@ def get_agent() -> Agent:
     if sns_topic_arn:
         tools.append(send_job_alert)
         system_prompt += SNS_NOTIFICATION_PROMPT
-        logging.info(f"SNS notifications enabled for topic: {sns_topic_arn}")
+        logger.info(f"SNS notifications enabled for topic: {sns_topic_arn}")
     else:
-        logging.info("SNS_TOPIC_ARN not configured, notifications disabled")
+        logger.info("SNS_TOPIC_ARN not configured, notifications disabled")
 
     return Agent(
         model=model,
@@ -197,20 +198,19 @@ async def run_job_search(company: str, title: str, location: str) -> dict[str, A
         # content can lead with thinking blocks; str() joins only the text blocks
         response_text = str(response)
 
-        logging.info(f"Agent response generated (length: {len(response_text)} chars)")
-        logging.info(f"Hiring result for {company}: {response_text}")
+        logger.info(f"Agent response generated (length: {len(response_text)} chars)")
 
         result = {
             "status": "success",
             "response": response_text,
             "search_criteria": {"company": company, "title": title, "location": location},
         }
-        logging.info("AgentCore invocation completed successfully")
+        logger.info("AgentCore invocation completed successfully")
 
         return result
 
     except Exception as e:
-        logging.error(f"Error processing request: {e}", exc_info=True)
+        logger.error(f"Error processing request: {e}", exc_info=True)
         return {"status": "error", "error": "Internal processing error"}
 
 
@@ -227,7 +227,7 @@ async def _tracked_job_search(task_id: int, company: str, title: str, location: 
         if result.get("status") != "success":
             send_failure_alert(company)
     except Exception:
-        logging.error(f"Background job search for {company} failed", exc_info=True)
+        logger.error(f"Background job search for {company} failed", exc_info=True)
         send_failure_alert(company)
     finally:
         app.complete_async_task(task_id)
@@ -247,8 +247,7 @@ async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     if not company:
         return {"status": "error", "error": "Company name is required"}
 
-    logging.info(f"Payload received: {payload}")
-    logging.info(f"Company: {company}, Title: {title}, Location: {location}")
+    logger.info(f"Company: {company}, Title: {title}, Location: {location}")
 
     if payload.get("sync"):
         return await run_job_search(company, title, location)

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -105,10 +105,12 @@ RECOGNIZING JOB LISTINGS:
 
 SNS_NOTIFICATION_PROMPT = """
 NOTIFICATION INSTRUCTIONS:
-After completing your response, if **Hiring Status** is Yes, send exactly ONE notification:
-1. Use the send_job_alert tool with subject="Job Alert: [COMPANY] is hiring!" and message=your full response text
-2. If the notification fails, still return your normal response - notification is best-effort
-3. Do NOT send more than one notification per request - never retry or send duplicate messages
+After completing your response, send exactly ONE notification:
+1. If **Hiring Status** is Yes: use the send_job_alert tool with subject="Job Alert: [COMPANY] is hiring!" and message=your full response text
+2. If you could not complete the search because your tools kept failing: use the send_job_alert tool with subject="Job search failed: [COMPANY]" and message=a brief description of what went wrong
+3. Otherwise (search worked, no matches): do not send a notification
+4. If the notification fails, still return your normal response - notification is best-effort
+5. Do NOT send more than one notification per request - never retry or send duplicate messages
 """
 # fmt: on
 

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -12,12 +12,13 @@ from strands_tools import current_time  # type: ignore[import-untyped]
 from strands_tools.tavily import tavily_extract, tavily_search  # type: ignore[import-untyped]
 
 from secret_utils import get_anthropic_api_key, get_tavily_api_key
-from tools import send_job_alert
+from tools import send_failure_alert, send_job_alert
 
 DEFAULT_MODEL_PROVIDER = "anthropic"
 DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
 DEFAULT_ANTHROPIC_MODEL_ID = "claude-sonnet-5"
 ANTHROPIC_MAX_TOKENS = 8192
+JOB_SEARCH_TIMEOUT_SECONDS = 900
 # Configure logging
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
@@ -217,11 +218,17 @@ async def run_job_search(company: str, title: str, location: str) -> dict[str, A
 _background_tasks: set[asyncio.Task[Any]] = set()
 
 
-async def _tracked_job_search(company: str, title: str, location: str) -> None:
-    """Run the job search as a tracked async task so ping reports HealthyBusy."""
-    task_id = app.add_async_task("job_search")
+async def _tracked_job_search(task_id: int, company: str, title: str, location: str) -> None:
+    """Run the job search, alerting on failure since the async caller discards the result."""
     try:
-        await run_job_search(company, title, location)
+        result = await asyncio.wait_for(
+            run_job_search(company, title, location), timeout=JOB_SEARCH_TIMEOUT_SECONDS
+        )
+        if result.get("status") != "success":
+            send_failure_alert(company)
+    except Exception:
+        logging.error(f"Background job search for {company} failed", exc_info=True)
+        send_failure_alert(company)
     finally:
         app.complete_async_task(task_id)
 
@@ -246,8 +253,10 @@ async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     if payload.get("sync"):
         return await run_job_search(company, title, location)
 
-    # Respond before EventBridge Scheduler's ~30s call timeout DLQs the invocation
-    task = asyncio.create_task(_tracked_job_search(company, title, location))
+    # Respond before EventBridge Scheduler's ~30s call timeout DLQs the invocation.
+    # Register the task before returning so /ping reports HealthyBusy while the search runs.
+    task_id = app.add_async_task("job_search")
+    task = asyncio.create_task(_tracked_job_search(task_id, company, title, location))
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
 

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -8,8 +8,8 @@ from typing import Any
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from strands import Agent
 from strands.models.anthropic import AnthropicModel
-from strands_tools import current_time, http_request  # type: ignore[import-untyped]
-from strands_tools.tavily import tavily_search  # type: ignore[import-untyped]
+from strands_tools import current_time  # type: ignore[import-untyped]
+from strands_tools.tavily import tavily_extract, tavily_search  # type: ignore[import-untyped]
 
 from secret_utils import get_anthropic_api_key, get_tavily_api_key
 from tools import send_job_alert
@@ -55,7 +55,7 @@ SEARCH PROCESS:
    - Query: "[COMPANY] careers jobs hiring"
    - Set max_results to 5
 4. From search results, identify the actual career page URL (look for URLs containing "careers", "jobs", or similar)
-5. Use http_request to fetch the career page content
+5. Use tavily_extract to fetch the career page content
 6. If career page has no job listings, use tavily_search for job boards:
    - Query: "[COMPANY] jobs site:indeed.com OR site:linkedin.com OR site:greenhouse.io"
 7. Parse all responses for actual job listings with real URLs
@@ -143,7 +143,7 @@ def get_agent() -> Agent:
 
     model = get_model()
 
-    tools: list[object] = [current_time, http_request, tavily_search]
+    tools: list[object] = [current_time, tavily_search, tavily_extract]
     system_prompt = SYSTEM_PROMPT
     sns_topic_arn = os.environ.get("SNS_TOPIC_ARN", "").strip()
     if sns_topic_arn:

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -15,7 +15,7 @@ from secret_utils import get_anthropic_api_key, get_tavily_api_key
 from tools import send_failure_alert, send_job_alert
 
 DEFAULT_MODEL_PROVIDER = "anthropic"
-DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-4-6"
+DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-5"
 DEFAULT_ANTHROPIC_MODEL_ID = "claude-sonnet-5"
 ANTHROPIC_MAX_TOKENS = 16000
 JOB_SEARCH_TIMEOUT_SECONDS = 900

--- a/agent/src/tools/__init__.py
+++ b/agent/src/tools/__init__.py
@@ -1,5 +1,5 @@
 """Tools module for the Strands agent."""
 
-from .sns_tools import send_job_alert
+from .sns_tools import send_failure_alert, send_job_alert
 
-__all__ = ["send_job_alert"]
+__all__ = ["send_failure_alert", "send_job_alert"]

--- a/agent/src/tools/sns_tools.py
+++ b/agent/src/tools/sns_tools.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 from strands import tool
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,11 @@ def send_job_alert(subject: str, message: str) -> str:
 
     sns = boto3.client("sns")
     # SNS rejects subjects over 100 characters
-    sns.publish(TopicArn=topic_arn, Subject=subject[:100], Message=message)
+    try:
+        sns.publish(TopicArn=topic_arn, Subject=subject[:100], Message=message)
+    except BotoCoreError, ClientError:
+        logger.error("Failed to publish job alert", exc_info=True)
+        return "Notification failed"
     logger.info(f"Job alert published to {topic_arn}")
     return "Notification sent"
 

--- a/agent/src/tools/sns_tools.py
+++ b/agent/src/tools/sns_tools.py
@@ -30,3 +30,21 @@ def send_job_alert(subject: str, message: str) -> str:
     sns.publish(TopicArn=topic_arn, Subject=subject[:100], Message=message)
     logger.info(f"Job alert published to {topic_arn}")
     return "Notification sent"
+
+
+def send_failure_alert(company: str) -> None:
+    """Alert when a background search fails — the async caller discards the result."""
+    topic_arn = os.environ.get("SNS_TOPIC_ARN", "").strip()
+    if not topic_arn:
+        return
+
+    try:
+        sns = boto3.client("sns")
+        sns.publish(
+            TopicArn=topic_arn,
+            Subject=f"Job search failed: {company}"[:100],
+            Message=f"The job search for {company} did not complete. "
+            "Check the runtime logs in CloudWatch.",
+        )
+    except Exception:
+        logger.error("Failed to publish failure alert", exc_info=True)

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -79,21 +79,6 @@ def test_get_model_unknown_provider_raises() -> None:
             get_model()
 
 
-def test_system_prompt_contains_filtering_rules() -> None:
-    """Test that system prompt contains strict filtering instructions."""
-    from src.agentcore_app import SYSTEM_PROMPT
-
-    # Check for key filtering concepts
-    assert "Strict filtering" in SYSTEM_PROMPT
-    assert "match ALL user criteria" in SYSTEM_PROMPT
-    assert "NEVER construct or invent URLs" in SYSTEM_PROMPT
-    assert "No direct link available" in SYSTEM_PROMPT
-
-    # Check for specific role matching examples
-    assert "Software Engineer" in SYSTEM_PROMPT
-    assert "does NOT match" in SYSTEM_PROMPT
-
-
 def test_construct_job_search_prompt_company_only() -> None:
     """Test prompt construction with company name only."""
     result = construct_job_search_prompt("Google")
@@ -104,15 +89,6 @@ def test_construct_job_search_prompt_with_all_params() -> None:
     """Test prompt construction with all parameters."""
     result = construct_job_search_prompt("Microsoft", title="Software Engineer", location="remote")
     assert result == "Find jobs at Microsoft. Focus on 'Software Engineer' roles in remote."
-
-
-def test_system_prompt_uses_search_approach() -> None:
-    """Test that system prompt uses tavily_search instead of URL guessing."""
-    from src.agentcore_app import SYSTEM_PROMPT
-
-    assert "tavily_search" in SYSTEM_PROMPT
-    # Old URL patterns should be removed
-    assert "https://careers.COMPANY.com" not in SYSTEM_PROMPT
 
 
 def test_agent_with_sns_has_send_job_alert_tool() -> None:

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -29,8 +29,8 @@ def test_agent_has_tools() -> None:
         agent = get_agent()
     tool_names = agent.tool_names
     assert "current_time" in tool_names
-    assert "http_request" in tool_names
     assert "tavily_search" in tool_names
+    assert "tavily_extract" in tool_names
 
 
 def test_get_model_default_is_anthropic() -> None:

--- a/agent/tests/test_agent.py
+++ b/agent/tests/test_agent.py
@@ -160,6 +160,22 @@ def test_invoke_default_returns_accepted_and_runs_search_in_background() -> None
     mock_search.assert_awaited_once_with("Stripe", "Engineer", "")
 
 
+def test_invoke_background_failure_sends_alert() -> None:
+    """Test a failed background search publishes a failure alert."""
+    mock_search = AsyncMock(return_value={"status": "error", "error": "Internal processing error"})
+
+    async def scenario() -> None:
+        with (
+            patch("src.agentcore_app.run_job_search", mock_search),
+            patch("src.agentcore_app.send_failure_alert") as mock_alert,
+        ):
+            await invoke({"company": "Stripe"})
+            await asyncio.gather(*_background_tasks)
+            mock_alert.assert_called_once_with("Stripe")
+
+    asyncio.run(scenario())
+
+
 def test_invoke_sync_returns_full_result() -> None:
     """Test the sync flag runs the search inline and returns its result."""
     full_result = {"status": "success", "response": "**Hiring Status**: Yes"}

--- a/agent/tests/test_secret_utils.py
+++ b/agent/tests/test_secret_utils.py
@@ -1,6 +1,7 @@
 """Tests for secret_utils module."""
 
 import os
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import pytest
@@ -15,14 +16,14 @@ from src.secret_utils import (
 
 
 @pytest.fixture(autouse=True)
-def clear_cache():
+def clear_cache() -> Iterator[None]:
     """Clear SSM cache before each test."""
     clear_ssm_cache()
     yield
     clear_ssm_cache()
 
 
-def test_aws_environment_uses_ssm_directly():
+def test_aws_environment_uses_ssm_directly() -> None:
     """In AWS, should fetch from SSM without checking env var."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=True),
@@ -34,7 +35,7 @@ def test_aws_environment_uses_ssm_directly():
         mock_ssm.assert_called_once_with(DEFAULT_TAVILY_SSM_PARAMETER)
 
 
-def test_local_uses_env_var_when_set():
+def test_local_uses_env_var_when_set() -> None:
     """Locally, should use env var if available without calling SSM."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=False),
@@ -47,7 +48,7 @@ def test_local_uses_env_var_when_set():
         mock_ssm.assert_not_called()
 
 
-def test_local_falls_back_to_ssm():
+def test_local_falls_back_to_ssm() -> None:
     """Locally without env var, should try SSM."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=False),
@@ -60,7 +61,7 @@ def test_local_falls_back_to_ssm():
         assert result == "ssm-fallback-key"
 
 
-def test_local_error_when_both_fail():
+def test_local_error_when_both_fail() -> None:
     """Locally without env var and SSM fails, should propagate SSM error."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=False),
@@ -75,7 +76,7 @@ def test_local_error_when_both_fail():
         assert "Parameter not found" in str(exc_info.value)
 
 
-def test_get_anthropic_api_key_local_env_var():
+def test_get_anthropic_api_key_local_env_var() -> None:
     """Locally, should use ANTHROPIC_API_KEY env var without calling SSM."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=False),
@@ -88,7 +89,7 @@ def test_get_anthropic_api_key_local_env_var():
         mock_ssm.assert_not_called()
 
 
-def test_get_anthropic_api_key_aws_uses_ssm():
+def test_get_anthropic_api_key_aws_uses_ssm() -> None:
     """In AWS, should fetch the Anthropic key from its own SSM parameter."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=True),
@@ -100,7 +101,7 @@ def test_get_anthropic_api_key_aws_uses_ssm():
         mock_ssm.assert_called_once_with(DEFAULT_ANTHROPIC_SSM_PARAMETER)
 
 
-def test_anthropic_ssm_parameter_env_override():
+def test_anthropic_ssm_parameter_env_override() -> None:
     """ANTHROPIC_API_KEY_SSM_PARAMETER should override the default parameter name."""
     with (
         patch("src.secret_utils.is_aws_environment", return_value=True),
@@ -112,7 +113,7 @@ def test_anthropic_ssm_parameter_env_override():
         mock_ssm.assert_called_once_with("/custom/param")
 
 
-def test_ssm_cache_isolated_per_parameter():
+def test_ssm_cache_isolated_per_parameter() -> None:
     """Distinct parameter names are cached independently; repeats hit the cache."""
     from src.secret_utils import _get_from_ssm
 

--- a/agent/tests/test_secret_utils.py
+++ b/agent/tests/test_secret_utils.py
@@ -61,21 +61,6 @@ def test_local_falls_back_to_ssm() -> None:
         assert result == "ssm-fallback-key"
 
 
-def test_local_error_when_both_fail() -> None:
-    """Locally without env var and SSM fails, should propagate SSM error."""
-    with (
-        patch("src.secret_utils.is_aws_environment", return_value=False),
-        patch.dict(os.environ, {}, clear=True),
-        patch("src.secret_utils._get_from_ssm", side_effect=ValueError("Parameter not found")),
-    ):
-        os.environ.pop("TAVILY_API_KEY", None)
-
-        with pytest.raises(ValueError) as exc_info:
-            get_tavily_api_key()
-
-        assert "Parameter not found" in str(exc_info.value)
-
-
 def test_get_anthropic_api_key_local_env_var() -> None:
     """Locally, should use ANTHROPIC_API_KEY env var without calling SSM."""
     with (

--- a/agent/tests/test_tools/test_sns_tools.py
+++ b/agent/tests/test_tools/test_sns_tools.py
@@ -3,10 +3,12 @@
 import os
 from unittest.mock import patch
 
+from botocore.exceptions import ClientError
+
 from src.tools.sns_tools import send_failure_alert, send_job_alert
 
 
-def test_send_job_alert_publishes_to_topic():
+def test_send_job_alert_publishes_to_topic() -> None:
     """Publishes subject and message to the topic from SNS_TOPIC_ARN."""
     topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
     with (
@@ -21,7 +23,7 @@ def test_send_job_alert_publishes_to_topic():
     )
 
 
-def test_send_job_alert_without_topic_is_noop():
+def test_send_job_alert_without_topic_is_noop() -> None:
     """Returns without publishing when SNS_TOPIC_ARN is not set."""
     with (
         patch.dict(os.environ, {}, clear=True),
@@ -33,7 +35,21 @@ def test_send_job_alert_without_topic_is_noop():
     mock_boto3.client.assert_not_called()
 
 
-def test_send_failure_alert_publishes_to_topic():
+def test_send_job_alert_returns_error_string_on_failure() -> None:
+    """Publish failures return a string for the model instead of raising."""
+    with (
+        patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:t"}),
+        patch("src.tools.sns_tools.boto3") as mock_boto3,
+    ):
+        mock_boto3.client.return_value.publish.side_effect = ClientError(
+            {"Error": {"Code": "InvalidParameter", "Message": "bad subject"}}, "Publish"
+        )
+        result = send_job_alert(subject="s", message="m")
+
+    assert result == "Notification failed"
+
+
+def test_send_failure_alert_publishes_to_topic() -> None:
     """Publishes a failure message naming the company to the configured topic."""
     topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
     with (
@@ -48,7 +64,7 @@ def test_send_failure_alert_publishes_to_topic():
     assert "Acme" in publish.call_args.kwargs["Subject"]
 
 
-def test_send_failure_alert_swallows_publish_errors():
+def test_send_failure_alert_swallows_publish_errors() -> None:
     """Never raises — failure alerts are best-effort."""
     with (
         patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:t"}),

--- a/agent/tests/test_tools/test_sns_tools.py
+++ b/agent/tests/test_tools/test_sns_tools.py
@@ -3,7 +3,7 @@
 import os
 from unittest.mock import patch
 
-from src.tools.sns_tools import send_job_alert
+from src.tools.sns_tools import send_failure_alert, send_job_alert
 
 
 def test_send_job_alert_publishes_to_topic():
@@ -31,3 +31,28 @@ def test_send_job_alert_without_topic_is_noop():
 
     assert result == "SNS notifications are not configured"
     mock_boto3.client.assert_not_called()
+
+
+def test_send_failure_alert_publishes_to_topic():
+    """Publishes a failure message naming the company to the configured topic."""
+    topic_arn = "arn:aws:sns:us-west-2:123456789012:test-topic"
+    with (
+        patch.dict(os.environ, {"SNS_TOPIC_ARN": topic_arn}),
+        patch("src.tools.sns_tools.boto3") as mock_boto3,
+    ):
+        send_failure_alert("Acme")
+
+    publish = mock_boto3.client.return_value.publish
+    publish.assert_called_once()
+    assert publish.call_args.kwargs["TopicArn"] == topic_arn
+    assert "Acme" in publish.call_args.kwargs["Subject"]
+
+
+def test_send_failure_alert_swallows_publish_errors():
+    """Never raises — failure alerts are best-effort."""
+    with (
+        patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:t"}),
+        patch("src.tools.sns_tools.boto3") as mock_boto3,
+    ):
+        mock_boto3.client.return_value.publish.side_effect = Exception("boom")
+        send_failure_alert("Acme")

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -35,7 +35,7 @@ Takes a few minutes. The stack builds a Docker image from `../agent`, pushes it 
 - **IAM Role** - Permissions for Bedrock models, SSM parameter reads (Tavily + Anthropic API keys), KMS decrypt (for SSM), and SNS publish
 - **ECR Image** - The agent image is pushed to the shared ECR repository that `cdk bootstrap` manages (the stack doesn't create its own repository)
 - **SNS Topic** - Receives hiring notifications; email subscriptions added when `NOTIFICATION_EMAILS` is set
-- **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry
+- **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry, with a CloudWatch alarm that notifies the SNS topic when invokes land in the DLQ
 
 The stack outputs `RuntimeId`, `RuntimeArn`, `TavilyApiKeyParameter`, `AnthropicApiKeyParameter`, and `NotificationTopicArn`.
 
@@ -50,16 +50,6 @@ npm run cdk:diff      # See what changed
 ```
 
 Tests validate IAM permissions, resource properties, and security configurations. Snapshots catch unintended infrastructure changes.
-
-## Stack Structure
-
-The stack follows this pattern:
-
-1. **IAM roles** - Set up permissions first
-2. **Core resources** - AgentCore Runtime with Docker build
-3. **Outputs** - Export RuntimeId, RuntimeArn, TavilyApiKeyParameter, AnthropicApiKeyParameter, and NotificationTopicArn
-
-All imports are explicit (no wildcards), and we use TypeScript strict mode.
 
 ## Customization
 

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,6 +4,16 @@ import { z } from 'zod'
 
 import { JobSearchAgentStack, ScheduleConfig } from '../lib/job-search-agent-stack'
 
+const scheduleSchema = z.object({
+  company: z.string().min(1),
+  title: z.string().optional(),
+  location: z.string().optional(),
+  schedule: z
+    .string()
+    .regex(/^(cron|rate)\(/, 'must be a cron(...) or rate(...) expression')
+    .optional(),
+})
+
 const envSchema = z
   .object({
     CDK_DEFAULT_ACCOUNT: z.string().optional(),
@@ -30,7 +40,17 @@ const envSchema = z
     SCHEDULES: z
       .string()
       .transform((s) => (s === '' ? undefined : s))
-      .optional(),
+      .optional()
+      .transform((s, ctx) => {
+        if (s === undefined) return undefined
+        try {
+          return JSON.parse(s) as unknown
+        } catch {
+          ctx.addIssue({ code: 'custom', message: 'must be valid JSON' })
+          return z.NEVER
+        }
+      })
+      .pipe(z.array(scheduleSchema).optional()),
     STACK_NAME: z
       .string()
       .transform((s) => (s === '' ? undefined : s))
@@ -46,7 +66,12 @@ const envSchema = z
       '❌ AWS region not found. Please configure AWS CLI credentials by running "aws configure", set AWS_PROFILE environment variable, or set CDK_DEFAULT_REGION environment variable.',
   })
 
-const env = envSchema.parse(process.env)
+const parsed = envSchema.safeParse(process.env)
+if (!parsed.success) {
+  console.error(z.prettifyError(parsed.error))
+  process.exit(1)
+}
+const env = parsed.data
 
 const account = (env.CDK_DEFAULT_ACCOUNT ?? env.AWS_DEFAULT_ACCOUNT_ID)!
 const region = (env.CDK_DEFAULT_REGION ?? env.AWS_DEFAULT_REGION)!
@@ -57,8 +82,6 @@ const notificationEmails = env.NOTIFICATION_EMAILS?.split(',')
   .map((e) => e.trim())
   .filter(Boolean)
 const schedules: ScheduleConfig[] | undefined = env.SCHEDULES
-  ? (JSON.parse(env.SCHEDULES) as ScheduleConfig[])
-  : undefined
 
 const app = new App()
 new JobSearchAgentStack(app, env.STACK_NAME, {

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -101,7 +101,7 @@ export class JobSearchAgentStack extends Stack {
       runtimeName: `${this.stackName.replace(/-/g, '_')}_JobSearchAgent`,
       agentRuntimeArtifact: agentArtifact,
       executionRole: agentRole,
-      description: 'Job search agent with web search, time, and http_request',
+      description: 'Job search agent with web search, page extraction, and time',
       environmentVariables: {
         AWS_REGION: this.region,
         AWS_DEFAULT_REGION: this.region,

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -1,4 +1,6 @@
 import { Stack, StackProps, CfnOutput, Duration } from 'aws-cdk-lib'
+import { Alarm, TreatMissingData } from 'aws-cdk-lib/aws-cloudwatch'
+import { SnsAction } from 'aws-cdk-lib/aws-cloudwatch-actions'
 import { Role, ServicePrincipal, PolicyStatement } from 'aws-cdk-lib/aws-iam'
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets'
 import { Topic } from 'aws-cdk-lib/aws-sns'
@@ -120,6 +122,15 @@ export class JobSearchAgentStack extends Stack {
         queueName: `${this.stackName}-scheduler-dlq`,
         retentionPeriod: Duration.days(14),
       })
+
+      new Alarm(this, 'SchedulerDlqAlarm', {
+        alarmName: `${this.stackName}-scheduler-dlq-alarm`,
+        alarmDescription: 'Scheduled job search invocations are failing and landing in the DLQ',
+        metric: dlq.metricApproximateNumberOfMessagesVisible(),
+        threshold: 1,
+        evaluationPeriods: 1,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      }).addAlarmAction(new SnsAction(notificationTopic))
 
       for (const [index, config] of props.schedules.entries()) {
         const payload: Record<string, string> = { company: config.company }

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -24,9 +24,9 @@ const ANTHROPIC_API_KEY_SSM_PARAMETER = '/job-search-agent/anthropic-api-key'
 
 export interface ScheduleConfig {
   company: string
-  title?: string
-  location?: string
-  schedule?: string // EventBridge expression, e.g. "cron(0 12 ? * MON *)" or "rate(14 days)"
+  title?: string | undefined
+  location?: string | undefined
+  schedule?: string | undefined // EventBridge expression, e.g. "cron(0 12 ? * MON *)" or "rate(14 days)"
 }
 
 interface AgentStackProps extends StackProps {
@@ -51,7 +51,8 @@ export class JobSearchAgentStack extends Stack {
         sid: 'BedrockModels',
         actions: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
         resources: [
-          'arn:aws:bedrock:*::foundation-model/*',
+          // region wildcard: cross-region inference profiles invoke the model outside this.region
+          'arn:aws:bedrock:*::foundation-model/anthropic.*',
           `arn:aws:bedrock:${this.region}:${this.account}:inference-profile/*`,
         ],
       })
@@ -132,7 +133,9 @@ export class JobSearchAgentStack extends Stack {
         treatMissingData: TreatMissingData.NOT_BREACHING,
       }).addAlarmAction(new SnsAction(notificationTopic))
 
-      for (const [index, config] of props.schedules.entries()) {
+      // Company-keyed IDs so reordering SCHEDULES doesn't retarget deployed schedules
+      const scheduleIdCounts = new Map<string, number>()
+      for (const config of props.schedules) {
         const payload: Record<string, string> = { company: config.company }
         if (config.title) payload.title = config.title
         if (config.location) payload.location = config.location
@@ -141,9 +144,14 @@ export class JobSearchAgentStack extends Stack {
           ? ScheduleExpression.expression(config.schedule)
           : ScheduleExpression.rate(Duration.days(7))
 
-        new Schedule(this, `Schedule-${index}`, {
+        const base = config.company.replace(/[^A-Za-z0-9_-]/g, '-').slice(0, 30)
+        const count = scheduleIdCounts.get(base) ?? 0
+        scheduleIdCounts.set(base, count + 1)
+        const scheduleId = count === 0 ? base : `${base}-${count + 1}`
+
+        new Schedule(this, `Schedule-${scheduleId}`, {
           schedule: scheduleExpr,
-          scheduleName: `${this.stackName}-Schedule-${index}`,
+          scheduleName: `${this.stackName}-Schedule-${scheduleId}`,
           target: new Universal({
             service: 'bedrockagentcore',
             action: 'invokeAgentRuntime',
@@ -154,7 +162,7 @@ export class JobSearchAgentStack extends Stack {
             policyStatements: [
               new PolicyStatement({
                 actions: ['bedrock-agentcore:InvokeAgentRuntime'],
-                resources: [`${runtime.agentRuntimeArn}*`],
+                resources: [runtime.agentRuntimeArn, `${runtime.agentRuntimeArn}/*`],
               }),
             ],
             retryAttempts: 2,

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -1,9 +1,8 @@
 {
   "name": "cdk",
   "version": "1.0.0",
-  "bin": {
-    "cdk": "bin/cdk.js"
-  },
+  "private": true,
+  "license": "MIT",
   "scripts": {
     "build": "tsc",
     "cdk": "cdk",

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -73,7 +73,7 @@ exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the ex
               ],
               "Effect": "Allow",
               "Resource": [
-                "arn:aws:bedrock:*::foundation-model/*",
+                "arn:aws:bedrock:*::foundation-model/anthropic.*",
                 "arn:aws:bedrock:us-west-2:123456789012:inference-profile/*",
               ],
               "Sid": "BedrockModels",
@@ -302,6 +302,588 @@ exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the ex
         "TopicName": "TestJobSearchAgentStack-notify",
       },
       "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": {
+    "CheckBootstrapVersion": {
+      "Assertions": [
+        {
+          "Assert": {
+            "Fn::Not": [
+              {
+                "Fn::Contains": [
+                  [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the expected template structure with schedules 1`] = `
+{
+  "Outputs": {
+    "AnthropicApiKeyParameter": {
+      "Description": "SSM Parameter name for Anthropic API Key (must be created before deployment when MODEL_PROVIDER is anthropic)",
+      "Value": "/job-search-agent/anthropic-api-key",
+    },
+    "NotificationTopicArn": {
+      "Description": "SNS Topic ARN for job search notifications",
+      "Value": {
+        "Ref": "JobSearchNotificationTopicA750FAD4",
+      },
+    },
+    "RuntimeArn": {
+      "Description": "AgentCore Runtime ARN",
+      "Value": {
+        "Fn::GetAtt": [
+          "JobSearchAgentRuntime978502A3",
+          "AgentRuntimeArn",
+        ],
+      },
+    },
+    "RuntimeId": {
+      "Description": "AgentCore Runtime ID",
+      "Value": {
+        "Fn::GetAtt": [
+          "JobSearchAgentRuntime978502A3",
+          "AgentRuntimeId",
+        ],
+      },
+    },
+    "TavilyApiKeyParameter": {
+      "Description": "SSM Parameter name for Tavily API Key (must be created before deployment)",
+      "Value": "/job-search-agent/tavily-api-key",
+    },
+  },
+  "Parameters": {
+    "BootstrapVersion": {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": {
+    "AgentCoreRoleD989E366": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "bedrock-agentcore.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "RoleName": "TestScheduleStack-AgentCoreRole",
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "AgentCoreRoleDefaultPolicyEB23C10B": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:bedrock:*::foundation-model/anthropic.*",
+                "arn:aws:bedrock:us-west-2:123456789012:inference-profile/*",
+              ],
+              "Sid": "BedrockModels",
+            },
+            {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:ssm:us-west-2:123456789012:parameter/job-search-agent/tavily-api-key",
+                "arn:aws:ssm:us-west-2:123456789012:parameter/job-search-agent/anthropic-api-key",
+              ],
+              "Sid": "SSMParameterAccess",
+            },
+            {
+              "Action": "kms:Decrypt",
+              "Condition": {
+                "StringEquals": {
+                  "kms:ViaService": "ssm.us-west-2.amazonaws.com",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+              "Sid": "KMSDecrypt",
+            },
+            {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "JobSearchNotificationTopicA750FAD4",
+              },
+            },
+            {
+              "Action": [
+                "logs:DescribeLogStreams",
+                "logs:CreateLogGroup",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-2:123456789012:log-group:/aws/bedrock-agentcore/runtimes/*",
+                  ],
+                ],
+              },
+              "Sid": "LogGroupAccess",
+            },
+            {
+              "Action": "logs:DescribeLogGroups",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-2:123456789012:log-group:*",
+                  ],
+                ],
+              },
+              "Sid": "DescribeLogGroups",
+            },
+            {
+              "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":logs:us-west-2:123456789012:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+                  ],
+                ],
+              },
+              "Sid": "LogStreamAccess",
+            },
+            {
+              "Action": [
+                "xray:PutTraceSegments",
+                "xray:PutTelemetryRecords",
+                "xray:GetSamplingRules",
+                "xray:GetSamplingTargets",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+              "Sid": "XRayAccess",
+            },
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Condition": {
+                "StringEquals": {
+                  "cloudwatch:namespace": "bedrock-agentcore",
+                },
+              },
+              "Effect": "Allow",
+              "Resource": "*",
+              "Sid": "CloudWatchMetrics",
+            },
+            {
+              "Action": [
+                "bedrock-agentcore:GetWorkloadAccessToken",
+                "bedrock-agentcore:GetWorkloadAccessTokenForJWT",
+                "bedrock-agentcore:GetWorkloadAccessTokenForUserId",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":bedrock-agentcore:us-west-2:123456789012:workload-identity-directory/default",
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":bedrock-agentcore:us-west-2:123456789012:workload-identity-directory/default/workload-identity/*",
+                    ],
+                  ],
+                },
+              ],
+              "Sid": "GetAgentAccessToken",
+            },
+            {
+              "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":ecr:us-west-2:123456789012:repository/cdk-hnb659fds-container-assets-123456789012-us-west-2",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "ecr:GetAuthorizationToken",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AgentCoreRoleDefaultPolicyEB23C10B",
+        "Roles": [
+          {
+            "Ref": "AgentCoreRoleD989E366",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "JobSearchAgentRuntime978502A3": {
+      "DependsOn": [
+        "AgentCoreRoleDefaultPolicyEB23C10B",
+        "AgentCoreRoleD989E366",
+      ],
+      "Properties": {
+        "AgentRuntimeArtifact": {
+          "ContainerConfiguration": {
+            "ContainerUri": {
+              "Fn::Sub": "123456789012.dkr.ecr.us-west-2.\${AWS::URLSuffix}/cdk-hnb659fds-container-assets-123456789012-us-west-2:MOCKED_CONTAINER_HASH",
+            },
+          },
+        },
+        "AgentRuntimeName": "TestScheduleStack_JobSearchAgent",
+        "Description": "Job search agent with web search, page extraction, and time",
+        "EnvironmentVariables": {
+          "ANTHROPIC_API_KEY_SSM_PARAMETER": "/job-search-agent/anthropic-api-key",
+          "AWS_DEFAULT_REGION": "us-west-2",
+          "AWS_REGION": "us-west-2",
+          "LOG_LEVEL": "INFO",
+          "MODEL_PROVIDER": "anthropic",
+          "SNS_TOPIC_ARN": {
+            "Ref": "JobSearchNotificationTopicA750FAD4",
+          },
+          "TAVILY_API_KEY_SSM_PARAMETER": "/job-search-agent/tavily-api-key",
+        },
+        "LifecycleConfiguration": {},
+        "NetworkConfiguration": {
+          "NetworkMode": "PUBLIC",
+        },
+        "ProtocolConfiguration": "HTTP",
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "AgentCoreRoleD989E366",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::BedrockAgentCore::Runtime",
+    },
+    "JobSearchNotificationTopicA750FAD4": {
+      "Properties": {
+        "DisplayName": "Job Search Agent Notifications",
+        "TopicName": "TestScheduleStack-notify",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "ScheduleGoogle3B516CEE": {
+      "Properties": {
+        "Description": "Job search: Google",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 120,
+          "Mode": "FLEXIBLE",
+        },
+        "Name": "TestScheduleStack-Schedule-Google",
+        "ScheduleExpression": "rate(7 days)",
+        "ScheduleExpressionTimezone": "Etc/UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":scheduler:::aws-sdk:bedrockagentcore:invokeAgentRuntime",
+              ],
+            ],
+          },
+          "DeadLetterConfig": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SchedulerdlqFAB10257",
+                "Arn",
+              ],
+            },
+          },
+          "Input": {
+            "Fn::Join": [
+              "",
+              [
+                "{"AgentRuntimeArn":"",
+                {
+                  "Fn::GetAtt": [
+                    "JobSearchAgentRuntime978502A3",
+                    "AgentRuntimeArn",
+                  ],
+                },
+                "","Payload":"{\\"company\\":\\"Google\\",\\"title\\":\\"Software Engineer\\",\\"location\\":\\"Remote\\"}"}",
+              ],
+            ],
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 2,
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "SchedulerRoleForTargeta5797e5F63D8AB",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::Scheduler::Schedule",
+    },
+    "ScheduleMeta9F41F9A3": {
+      "Properties": {
+        "Description": "Job search: Meta",
+        "FlexibleTimeWindow": {
+          "MaximumWindowInMinutes": 120,
+          "Mode": "FLEXIBLE",
+        },
+        "Name": "TestScheduleStack-Schedule-Meta",
+        "ScheduleExpression": "cron(0 12 ? * MON *)",
+        "ScheduleExpressionTimezone": "Etc/UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":scheduler:::aws-sdk:bedrockagentcore:invokeAgentRuntime",
+              ],
+            ],
+          },
+          "DeadLetterConfig": {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SchedulerdlqFAB10257",
+                "Arn",
+              ],
+            },
+          },
+          "Input": {
+            "Fn::Join": [
+              "",
+              [
+                "{"AgentRuntimeArn":"",
+                {
+                  "Fn::GetAtt": [
+                    "JobSearchAgentRuntime978502A3",
+                    "AgentRuntimeArn",
+                  ],
+                },
+                "","Payload":"{\\"company\\":\\"Meta\\"}"}",
+              ],
+            ],
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 2,
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "SchedulerRoleForTargeta5797e5F63D8AB",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::Scheduler::Schedule",
+    },
+    "SchedulerDlqAlarm0171B2A8": {
+      "Properties": {
+        "AlarmActions": [
+          {
+            "Ref": "JobSearchNotificationTopicA750FAD4",
+          },
+        ],
+        "AlarmDescription": "Scheduled job search invocations are failing and landing in the DLQ",
+        "AlarmName": "TestScheduleStack-scheduler-dlq-alarm",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "QueueName",
+            "Value": {
+              "Fn::GetAtt": [
+                "SchedulerdlqFAB10257",
+                "QueueName",
+              ],
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ApproximateNumberOfMessagesVisible",
+        "Namespace": "AWS/SQS",
+        "Period": 300,
+        "Statistic": "Maximum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "SchedulerRoleForTargeta5797e5F63D8AB": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "123456789012",
+                  "aws:SourceArn": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":scheduler:us-west-2:123456789012:schedule-group/default",
+                      ],
+                    ],
+                  },
+                },
+              },
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "scheduler.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "SchedulerRoleForTargeta5797eDefaultPolicy274DDE39": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "bedrock-agentcore:InvokeAgentRuntime",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "JobSearchAgentRuntime978502A3",
+                    "AgentRuntimeArn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "JobSearchAgentRuntime978502A3",
+                          "AgentRuntimeArn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SchedulerdlqFAB10257",
+                  "Arn",
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SchedulerRoleForTargeta5797eDefaultPolicy274DDE39",
+        "Roles": [
+          {
+            "Ref": "SchedulerRoleForTargeta5797e5F63D8AB",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SchedulerdlqFAB10257": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 1209600,
+        "QueueName": "TestScheduleStack-scheduler-dlq",
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
     },
   },
   "Rules": {

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -270,7 +270,7 @@ exports[`JobSearchAgentStack > CloudFormation Template Snapshot > matches the ex
           },
         },
         "AgentRuntimeName": "TestJobSearchAgentStack_JobSearchAgent",
-        "Description": "Job search agent with web search, time, and http_request",
+        "Description": "Job search agent with web search, page extraction, and time",
         "EnvironmentVariables": {
           "ANTHROPIC_API_KEY_SSM_PARAMETER": "/job-search-agent/anthropic-api-key",
           "AWS_DEFAULT_REGION": "us-west-2",

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -3,6 +3,22 @@ import { App } from 'aws-cdk-lib'
 import { Template, Match } from 'aws-cdk-lib/assertions'
 import { JobSearchAgentStack } from '../lib/job-search-agent-stack'
 
+const makeScheduleTemplate = () => {
+  const app = new App()
+  const stack = new JobSearchAgentStack(app, 'TestScheduleStack', {
+    env: { account: '123456789012', region: 'us-west-2' },
+    schedules: [
+      { company: 'Google', title: 'Software Engineer', location: 'Remote' },
+      { company: 'Meta', schedule: 'cron(0 12 ? * MON *)' },
+    ],
+  })
+  return Template.fromStack(stack)
+}
+
+// Replace dynamic containerUri hash with stable placeholder for snapshot testing
+const normalize = (template: Template): unknown =>
+  JSON.parse(JSON.stringify(template.toJSON()).replace(/:[\da-f]{64}"/g, ':MOCKED_CONTAINER_HASH"'))
+
 describe('JobSearchAgentStack', () => {
   let app: App
   let stack: JobSearchAgentStack
@@ -44,7 +60,7 @@ describe('JobSearchAgentStack', () => {
               Action: ['bedrock:InvokeModel', 'bedrock:InvokeModelWithResponseStream'],
               Effect: 'Allow',
               Resource: [
-                'arn:aws:bedrock:*::foundation-model/*',
+                'arn:aws:bedrock:*::foundation-model/anthropic.*',
                 Match.stringLikeRegexp('arn:aws:bedrock:.+:.+:inference-profile/\\*'),
               ],
             }),
@@ -192,15 +208,7 @@ describe('JobSearchAgentStack', () => {
     let scheduleTemplate: Template
 
     beforeEach(() => {
-      const scheduleApp = new App()
-      const scheduleStack = new JobSearchAgentStack(scheduleApp, 'TestScheduleStack', {
-        env: { account: '123456789012', region: 'us-west-2' },
-        schedules: [
-          { company: 'Google', title: 'Software Engineer', location: 'Remote' },
-          { company: 'Meta', schedule: 'cron(0 12 ? * MON *)' },
-        ],
-      })
-      scheduleTemplate = Template.fromStack(scheduleStack)
+      scheduleTemplate = makeScheduleTemplate()
     })
 
     it('creates one schedule per configured company', () => {
@@ -238,17 +246,78 @@ describe('JobSearchAgentStack', () => {
         }),
       })
     })
+
+    it('names schedules after the company so reordering does not retarget them', () => {
+      scheduleTemplate.hasResourceProperties('AWS::Scheduler::Schedule', {
+        Name: 'TestScheduleStack-Schedule-Google',
+      })
+      scheduleTemplate.hasResourceProperties('AWS::Scheduler::Schedule', {
+        Name: 'TestScheduleStack-Schedule-Meta',
+      })
+    })
+
+    it('configures retries, DLQ, and a flexible time window on each schedule', () => {
+      scheduleTemplate.hasResourceProperties('AWS::Scheduler::Schedule', {
+        FlexibleTimeWindow: { Mode: 'FLEXIBLE', MaximumWindowInMinutes: 120 },
+        Target: Match.objectLike({
+          RetryPolicy: Match.objectLike({ MaximumRetryAttempts: 2 }),
+          DeadLetterConfig: {
+            Arn: { 'Fn::GetAtt': [Match.stringLikeRegexp('Schedulerdlq.*'), 'Arn'] },
+          },
+        }),
+      })
+    })
+
+    it('scopes the scheduler role to the runtime ARN', () => {
+      scheduleTemplate.hasResourceProperties('AWS::IAM::Policy', {
+        PolicyDocument: {
+          Statement: Match.arrayWith([
+            Match.objectLike({
+              Action: 'bedrock-agentcore:InvokeAgentRuntime',
+              Resource: [
+                {
+                  'Fn::GetAtt': [
+                    Match.stringLikeRegexp('JobSearchAgentRuntime.*'),
+                    'AgentRuntimeArn',
+                  ],
+                },
+                {
+                  'Fn::Join': [
+                    '',
+                    [
+                      {
+                        'Fn::GetAtt': [
+                          Match.stringLikeRegexp('JobSearchAgentRuntime.*'),
+                          'AgentRuntimeArn',
+                        ],
+                      },
+                      '/*',
+                    ],
+                  ],
+                },
+              ],
+            }),
+          ]),
+        },
+      })
+    })
+
+    it('alarms on DLQ messages to the notification topic', () => {
+      scheduleTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+        MetricName: 'ApproximateNumberOfMessagesVisible',
+        Threshold: 1,
+        AlarmActions: [{ Ref: Match.stringLikeRegexp('JobSearchNotificationTopic.*') }],
+      })
+    })
   })
 
   describe('CloudFormation Template Snapshot', () => {
     it('matches the expected template structure', () => {
-      const templateJson = template.toJSON()
+      expect(normalize(template)).toMatchSnapshot()
+    })
 
-      // Replace dynamic containerUri hash with stable placeholder for snapshot testing
-      const templateString = JSON.stringify(templateJson)
-      const normalizedTemplate = templateString.replace(/:[\da-f]{64}"/g, ':MOCKED_CONTAINER_HASH"')
-
-      expect(JSON.parse(normalizedTemplate)).toMatchSnapshot()
+    it('matches the expected template structure with schedules', () => {
+      expect(normalize(makeScheduleTemplate())).toMatchSnapshot()
     })
   })
 })

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -91,7 +91,7 @@ describe('JobSearchAgentStack', () => {
     it('creates AgentCore runtime with proper configuration', () => {
       template.hasResourceProperties('AWS::BedrockAgentCore::Runtime', {
         AgentRuntimeName: 'TestJobSearchAgentStack_JobSearchAgent',
-        Description: 'Job search agent with web search, time, and http_request',
+        Description: 'Job search agent with web search, page extraction, and time',
         RoleArn: {
           'Fn::GetAtt': [Match.stringLikeRegexp('AgentCoreRole.*'), 'Arn'],
         },

--- a/cdk/test/cdk.test.ts
+++ b/cdk/test/cdk.test.ts
@@ -157,34 +157,6 @@ describe('JobSearchAgentStack', () => {
         }),
       })
     })
-
-    it('creates stack outputs for runtime access', () => {
-      template.hasOutput('RuntimeId', {
-        Description: 'AgentCore Runtime ID',
-        Value: {
-          'Fn::GetAtt': [Match.stringLikeRegexp('JobSearchAgentRuntime.*'), 'AgentRuntimeId'],
-        },
-      })
-
-      template.hasOutput('RuntimeArn', {
-        Description: 'AgentCore Runtime ARN',
-        Value: {
-          'Fn::GetAtt': [Match.stringLikeRegexp('JobSearchAgentRuntime.*'), 'AgentRuntimeArn'],
-        },
-      })
-
-      template.hasOutput('AnthropicApiKeyParameter', {
-        Description: Match.stringLikeRegexp('SSM Parameter name for Anthropic API Key.*'),
-        Value: '/job-search-agent/anthropic-api-key',
-      })
-
-      template.hasOutput('NotificationTopicArn', {
-        Description: Match.stringLikeRegexp('SNS Topic ARN.*'),
-        Value: {
-          Ref: Match.stringLikeRegexp('JobSearchNotificationTopic.*'),
-        },
-      })
-    })
   })
 
   describe('SNS Notifications', () => {


### PR DESCRIPTION
Cleanup pass: security, reliability, IAM, onboarding, tests, docs.

- d694bb0 — Fetch pages server-side via Tavily; removes the SSRF/SigV4 surface
- 4af31df — Alert on async failures: SNS on agent errors, alarm on the DLQ
- 665e975 — Scope scheduler IAM, validate `SCHEDULES` at synth, key schedules by company
- 8495a13 — MIT license, runnable Quick Start, architecture diagram
- 69b0756 — Raise max_tokens, trim logging, harden tool errors, drop unused CI permissions
- 9dfd65b — Drop tests of constants and framework behavior
- c6ed47b — Fix doc drift
- b101928 — Default Bedrock to Claude Sonnet 5, matching the Anthropic API default
- 405225b — Alert on tool-level search failures the model survives (found via live testing; code-level alert only covers crashes/timeouts)

Next deploy: expect a busy `cdk diff` — schedules get replaced (stateless) and IAM narrows.
