### PR TITLE
Add cost breakdown and trim doc boilerplate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,6 @@
 
 ## Conventions
 
-- **Env vars**: all in `agent/.env` — loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
-- **CDK imports**: explicit only, no wildcards — e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
+- **Env vars**: all in `agent/.env`, loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
+- **CDK imports**: explicit only, no wildcards, e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
 - **AgentCore regions**: not available everywhere; check the [AWS availability page](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) before deploying. CI deploys to us-west-2. Not enforced in code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,50 +108,16 @@ npm run cdk:deploy   # Deploy to AWS
 - **Formatter**: Prettier
 - **Linter**: ESLint
 - **Testing**: Vitest with snapshot testing
-- **Imports**: Use explicit imports, avoid wildcards
-
-**Good TypeScript imports:**
-
-```typescript
-// ✅ Good
-import { Stack, StackProps, CfnOutput, Duration } from 'aws-cdk-lib'
-import { Runtime, AgentRuntimeArtifact } from 'aws-cdk-lib/aws-bedrockagentcore'
-
-// ❌ Avoid
-import * as cdk from 'aws-cdk-lib'
-```
+- **Imports**: Use explicit imports (`import { Stack } from 'aws-cdk-lib'`), never wildcards (`import * as cdk`)
 
 ## Project Structure
 
 ### Adding New Job Search Tools
 
 1. **Create tool file** in `agent/src/tools/` (see `sns_tools.py` for an existing example)
-2. **Implement with `@tool` decorator** and proper type hints for job search functionality
+2. **Implement with `@tool` decorator** and proper type hints
 3. **Export in `__init__.py`**
 4. **Add tests** in `agent/tests/test_tools/`
-
-Example job search tool structure:
-
-```python
-from strands import tool
-
-@tool
-def search_job_board(company_name: str, position_type: str) -> dict:
-    """Search job board API for company positions."""
-    return {
-        "company": company_name,
-        "jobs": [{"title": "...", "link": "...", "posted_date": "..."}]
-    }
-```
-
-### Current Tool Usage
-
-The agent uses community tools from `strands-agents-tools`, plus one custom tool:
-
-- `tavily_search` - For searching the web for career pages and job listings
-- `tavily_extract` - For fetching page content from URLs found by search
-- `current_time` - For timestamping search results
-- `send_job_alert` - Custom tool in `agent/src/tools/sns_tools.py` that publishes SNS notifications (conditionally loaded when `SNS_TOPIC_ARN` is set)
 
 ### Testing Guidelines
 
@@ -159,7 +125,7 @@ The agent uses community tools from `strands-agents-tools`, plus one custom tool
 
 - Mirror source structure in `tests/` directory
 - Test both success and error cases
-- Test this project's logic, not framework behavior — skip tests that only restate constants or assert things the language/CDK guarantees
+- Test this project's logic, not framework behavior; skip tests that only restate constants or assert things the language/CDK guarantees
 
 **CDK tests:**
 
@@ -175,13 +141,7 @@ The agent uses community tools from `strands-agents-tools`, plus one custom tool
 git checkout -b feature/your-feature-name
 ```
 
-### 2. Make Your Changes
-
-- Follow the code standards outlined above
-- Add tests for new functionality
-- Update documentation as needed
-
-### 3. Run Quality Checks
+### 2. Run Quality Checks
 
 **For Python changes:**
 
@@ -197,21 +157,15 @@ cd cdk
 npm run build && npm test && npm run lint
 ```
 
-### 4. Commit Your Changes
+### 3. Commit Your Changes
 
 Write commit messages as short plain sentences describing the change, e.g. "Add async invoke path for eventbridge universal target".
 
-### 5. Push and Create Pull Request
+### 4. Push and Create Pull Request
 
 ```bash
 git push origin feature/your-feature-name
 ```
-
-Create a pull request with:
-
-- Clear description of changes
-- Reference to any related issues
-- Screenshots/examples if applicable
 
 ## CI/CD Pipeline
 
@@ -236,14 +190,7 @@ All checks must pass before merging.
 
 ## Community Tools
 
-We use `strands-agents-tools` for common functionality:
-
-```python
-from strands_tools import current_time
-from strands_tools.tavily import tavily_extract, tavily_search
-```
-
-When adding tools, consider if they should be:
+We use `strands-agents-tools` for common functionality. When adding tools, consider if they should be:
 
 - **Custom tools** (domain-specific to your use case)
 - **Community contributions** (general-purpose, consider contributing upstream)
@@ -251,11 +198,9 @@ When adding tools, consider if they should be:
 ## Getting Help
 
 - **Issues**: Create GitHub issues for bugs, feature requests, or questions
-- **Documentation**: Check README.md and DEPLOYMENT.md for guidance
 
 ## Code of Conduct
 
 - Be respectful and inclusive
 - Focus on constructive feedback
 - Help others learn and grow
-- Follow our coding standards consistently

--- a/COST.md
+++ b/COST.md
@@ -1,0 +1,41 @@
+# What It Costs
+
+Real numbers from running this project: about **$10–14/month**. The infrastructure is roughly 50¢/month; the LLM inference is everything else.
+
+> **Disclaimer:** These figures come from actual AWS Cost Explorer data for **May–July 2026**, for a single deployment in us-west-2. AWS pricing, free tiers, and model rates change. Verify against [Amazon Bedrock pricing](https://aws.amazon.com/bedrock/pricing/) and [AgentCore pricing](https://aws.amazon.com/bedrock/agentcore/pricing/) before relying on these numbers.
+
+## Usage Profile
+
+The numbers below reflect this workload:
+
+- 5 weekly EventBridge schedules (one company per weekday), about 22 agent runs/month
+- `MODEL_PROVIDER=bedrock` with Claude Sonnet 4.6
+- Each agent run costs roughly **$0.45–0.65**, nearly all of it model inference
+
+## Monthly Breakdown
+
+| Service | Cost/month | Notes |
+|---|---|---|
+| Bedrock model inference | **~$10–14** | ~95% of the total (May $12.65, Jun $9.94, Jul $13.57) |
+| Bedrock AgentCore Runtime | **~$0.20–0.30** | Consumption-based (GB-hours + vCPU-hours); no idle charge |
+| ECR (container images) | **~$0.07–0.25** | Grows as deployed runtime versions accumulate |
+| CloudWatch (logs/metrics) | **~$0.01–0.02** | Mostly inside the 5 GB/month free ingest tier |
+| EventBridge Scheduler | **$0** | 22 invocations vs. 14M free/month |
+| SNS (email alerts) | **$0** | First 1,000 email notifications/month free |
+| SQS (scheduler DLQ) | **$0** | First 1M requests/month free |
+| SSM Parameter Store | **$0** | Standard-tier parameters are free |
+| KMS | **$0** | AWS-managed key, within the free request tier |
+| S3 (CDK assets) | **~pennies** | Bootstrap staging bucket |
+| **Total** | **≈ $10–14/month** | |
+
+## Scheduled Runs vs. Development
+
+The totals above are actual charges, which include manual test invokes and deploy-day smoke tests alongside the scheduled runs. A steady-state "set it and forget it" month (schedules only) comes out to roughly **$9–11/month** (22 runs × ~$0.45–0.55). Testing barely moves the infrastructure rows; the difference is almost entirely model inference.
+
+## Model Provider Matters
+
+These numbers are from a `MODEL_PROVIDER=bedrock` deployment, so model inference shows up on the AWS bill. The repo's *default* is `MODEL_PROVIDER=anthropic`, which calls the Anthropic API directly. With that config, inference bills to your Anthropic account at [Anthropic API pricing](https://claude.com/pricing) instead, and the AWS bill only shows the ~50¢ of infrastructure. Cost also varies by model; see [Change the Model or Provider](DEPLOYMENT.md#change-the-model-or-provider).
+
+## External: Tavily
+
+Web search cost **$0**. At ~22 runs/month with a handful of search/extract calls per run, this usage fits well within Tavily's free tier (1,000 API credits/month at the time of writing). Heavier schedules would eventually need a paid plan; see [Tavily pricing](https://www.tavily.com/pricing) for current limits.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Deployment Guide
 
-Get the job search agent running on AWS in minutes.
+Get the job search agent running on AWS in minutes. Curious what it costs to run? See [COST.md](COST.md).
 
 ## What You Need
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -8,7 +8,7 @@ Get the job search agent running on AWS in minutes. Curious what it costs to run
 - Docker running locally
 - Node.js 24 and Python 3.14
 - [uv](https://docs.astral.sh/uv/) for Python package management
-- Anthropic API key (sign up at [console.anthropic.com](https://console.anthropic.com)) — or Bedrock model access in your AWS account when using `MODEL_PROVIDER=bedrock`
+- Anthropic API key (sign up at [console.anthropic.com](https://console.anthropic.com)), or Bedrock model access in your AWS account when using `MODEL_PROVIDER=bedrock`
 - Tavily API key (sign up at [tavily.com](https://tavily.com) - free tier available)
 
 Check [Amazon Bedrock AgentCore regions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) to make sure AgentCore is available where you want to deploy.
@@ -61,7 +61,7 @@ To receive email alerts when companies are hiring, add emails to `agent/.env` (c
 NOTIFICATION_EMAILS=your-email@example.com,teammate@example.com
 ```
 
-After deploying, each address will receive a confirmation email — click the link to activate notifications.
+After deploying, each address will receive a confirmation email; click the link to activate notifications.
 
 ### 3. Bootstrap and Deploy
 
@@ -123,8 +123,8 @@ aws logs tail /aws/bedrock-agentcore/runtimes/JobSearchAgentStack_JobSearchAgent
 
 The agent supports two model providers, selected with `MODEL_PROVIDER` in `agent/.env`:
 
-- **`anthropic`** (default) — calls the Anthropic API directly. Requires the Anthropic API key (SSM parameter above). Override the model with `ANTHROPIC_MODEL_ID` (default: `claude-sonnet-5`); see [Anthropic model IDs](https://docs.claude.com/en/docs/about-claude/models/overview).
-- **`bedrock`** — uses Amazon Bedrock with the runtime's IAM role. Requires Bedrock model access in your account. Override the model with `BEDROCK_MODEL_ID` (default: `us.anthropic.claude-sonnet-5`); see [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
+- **`anthropic`** (default): calls the Anthropic API directly. Requires the Anthropic API key (SSM parameter above). Override the model with `ANTHROPIC_MODEL_ID` (default: `claude-sonnet-5`); see [Anthropic model IDs](https://docs.claude.com/en/docs/about-claude/models/overview).
+- **`bedrock`**: uses Amazon Bedrock with the runtime's IAM role. Requires Bedrock model access in your account. Override the model with `BEDROCK_MODEL_ID` (default: `us.anthropic.claude-sonnet-5`); see [Amazon Bedrock model IDs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-ids.html).
 
 ```bash
 MODEL_PROVIDER=bedrock
@@ -209,7 +209,7 @@ Each entry creates an EventBridge schedule that invokes the agent automatically.
 - **`company`** (required): Company name to search
 - **`title`** (optional): Job title filter
 - **`location`** (optional): Location filter
-- **`schedule`** (optional): EventBridge expression — `cron(...)` or `rate(...)`. Defaults to `rate(7 days)`
+- **`schedule`** (optional): EventBridge expression, `cron(...)` or `rate(...)`. Defaults to `rate(7 days)`
 
 Then redeploy:
 
@@ -219,7 +219,7 @@ cd cdk && npm run cdk:deploy
 
 The agent sends SNS notifications when it finds open positions, so pair this with `NOTIFICATION_EMAILS` for automated alerts.
 
-Scheduled invokes are async — the runtime acks immediately (EventBridge Scheduler's call times out after ~30s) and results arrive via SNS email or CloudWatch logs. Failed invokes land in an SQS dead-letter queue that alarms to the same SNS topic; failures inside the agent send their own SNS alert. To spread load, each schedule fires within a 2-hour window after its scheduled time, not at the exact minute.
+Scheduled invokes are async: the runtime acks immediately (EventBridge Scheduler's call times out after ~30s) and results arrive via SNS email or CloudWatch logs. Failed invokes go to an SQS dead-letter queue that alarms to the same SNS topic; failures inside the agent send their own SNS alert. To spread load, each schedule fires within a 2-hour window after its scheduled time, not at the exact minute.
 
 ## Clean Up
 

--- a/README.md
+++ b/README.md
@@ -84,4 +84,6 @@ flowchart LR
 
 **Ready to deploy to AWS?** See [DEPLOYMENT.md](DEPLOYMENT.md)
 
+**Wondering what it costs to run?** See [COST.md](COST.md)
+
 **Want a more detailed write up of the background of how this came to be?** Read [this blogpost](https://danielleheberling.xyz/blog/job-search-agent/)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built with [Strands Agents](https://strandsagents.com) and deployed to Amazon Be
 
 ## Quick Start
 
-Prerequisites: [uv](https://docs.astral.sh/uv/) 0.11, Python 3.14, Node 24, Docker, and AWS CLI credentials — see [DEPLOYMENT.md](DEPLOYMENT.md). Running locally only needs uv and the API keys.
+Prerequisites: [uv](https://docs.astral.sh/uv/) 0.11, Python 3.14, Node 24, Docker, and AWS CLI credentials; see [DEPLOYMENT.md](DEPLOYMENT.md). Running locally only needs uv and the API keys.
 
 ```bash
 # Get API keys: Anthropic (https://console.anthropic.com)

--- a/agent/README.md
+++ b/agent/README.md
@@ -1,6 +1,6 @@
 # Agent Development
 
-The Python side of the job search agent. This is where the AI magic happens.
+The Python side of the job search agent.
 
 ## Running Locally
 
@@ -24,7 +24,7 @@ curl -X POST http://localhost:8080/invocations \
   -d '{"company": "Stripe", "title": "Engineer", "sync": true}'
 ```
 
-`"sync": true` returns the full result. Without it the agent replies `{"status": "accepted"}` immediately and logs the result when done — the mode scheduled invokes use, since EventBridge Scheduler's call times out after ~30s.
+`"sync": true` returns the full result. Without it the agent replies `{"status": "accepted"}` immediately and logs the result when done. Scheduled invokes use this mode, since EventBridge Scheduler's call times out after ~30s.
 
 ## How It Works
 

--- a/agent/src/agentcore_app.py
+++ b/agent/src/agentcore_app.py
@@ -19,7 +19,7 @@ DEFAULT_BEDROCK_MODEL_ID = "us.anthropic.claude-sonnet-5"
 DEFAULT_ANTHROPIC_MODEL_ID = "claude-sonnet-5"
 ANTHROPIC_MAX_TOKENS = 16000
 JOB_SEARCH_TIMEOUT_SECONDS = 900
-# Configure logging
+
 log_level = os.getenv("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
@@ -140,8 +140,7 @@ def get_model() -> str | AnthropicModel:
 
 def get_agent() -> Agent:
     """Create and return a Strands agent with configured tools and model."""
-    # Ensure Tavily API key is available (fetches from SSM in AWS, env var locally)
-    # strands_tools.tavily reads from TAVILY_API_KEY env var internally
+    # strands_tools.tavily reads the key from the TAVILY_API_KEY env var internally
     tavily_key = get_tavily_api_key()
     os.environ["TAVILY_API_KEY"] = tavily_key
 
@@ -165,18 +164,7 @@ def get_agent() -> Agent:
 
 
 def construct_job_search_prompt(company: str, title: str = "", location: str = "") -> str:
-    """
-    Construct a job search prompt based on the provided parameters.
-
-    Args:
-        company: Company name to search (required)
-        title: Job title/role to search for (optional)
-        location: Job location (can be "remote", city/state, or country) (optional)
-
-    Returns:
-        str: Formatted prompt for the job search agent
-    """
-
+    """Build the job search prompt from the company plus optional title/location filters."""
     prompt_parts = [f"Find jobs at {company}."]
 
     if title and location:
@@ -241,7 +229,6 @@ async def invoke(payload: dict[str, Any] | None = None) -> dict[str, Any]:
     if not payload:
         return {"status": "error", "error": "Payload is required"}
 
-    # Extract parameters from payload
     company = payload.get("company", "")
     title = payload.get("title", "")
     location = payload.get("location", "")

--- a/agent/src/secret_utils.py
+++ b/agent/src/secret_utils.py
@@ -13,12 +13,7 @@ DEFAULT_ANTHROPIC_SSM_PARAMETER = "/job-search-agent/anthropic-api-key"
 
 
 def is_aws_environment() -> bool:
-    """
-    Detect if running in AWS environment.
-
-    AgentCore Runtime and other AWS compute services set environment variables
-    that indicate we're running in AWS.
-    """
+    """Detect AWS via env vars set by AgentCore Runtime and other AWS compute services."""
     aws_indicators = [
         "AWS_EXECUTION_ENV",
         "AWS_LAMBDA_FUNCTION_NAME",

--- a/agent/src/tools/sns_tools.py
+++ b/agent/src/tools/sns_tools.py
@@ -38,7 +38,7 @@ def send_job_alert(subject: str, message: str) -> str:
 
 
 def send_failure_alert(company: str) -> None:
-    """Alert when a background search fails — the async caller discards the result."""
+    """Alert when a background search fails; the async caller discards the result."""
     topic_arn = os.environ.get("SNS_TOPIC_ARN", "").strip()
     if not topic_arn:
         return

--- a/agent/tests/test_tools/test_sns_tools.py
+++ b/agent/tests/test_tools/test_sns_tools.py
@@ -65,7 +65,7 @@ def test_send_failure_alert_publishes_to_topic() -> None:
 
 
 def test_send_failure_alert_swallows_publish_errors() -> None:
-    """Never raises — failure alerts are best-effort."""
+    """Never raises; failure alerts are best-effort."""
     with (
         patch.dict(os.environ, {"SNS_TOPIC_ARN": "arn:aws:sns:us-west-2:123456789012:t"}),
         patch("src.tools.sns_tools.boto3") as mock_boto3,

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -35,7 +35,7 @@ Takes a few minutes. The stack builds a Docker image from `../agent`, pushes it 
 - **IAM Role** - Permissions for Bedrock models, SSM parameter reads (Tavily + Anthropic API keys), KMS decrypt (for SSM), and SNS publish
 - **ECR Image** - The agent image is pushed to the shared ECR repository that `cdk bootstrap` manages (the stack doesn't create its own repository)
 - **SNS Topic** - Receives hiring notifications; email subscriptions added when `NOTIFICATION_EMAILS` is set
-- **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry, with a CloudWatch alarm that notifies the SNS topic when invokes land in the DLQ
+- **EventBridge Schedules + SQS DLQ** _(optional)_ - Created when `SCHEDULES` is set, one schedule per entry, with a CloudWatch alarm that notifies the SNS topic when invokes go to the DLQ
 
 The stack outputs `RuntimeId`, `RuntimeArn`, `TavilyApiKeyParameter`, `AnthropicApiKeyParameter`, and `NotificationTopicArn`.
 

--- a/cdk/lib/job-search-agent-stack.ts
+++ b/cdk/lib/job-search-agent-stack.ts
@@ -69,7 +69,6 @@ export class JobSearchAgentStack extends Stack {
       })
     )
 
-    // KMS Decrypt for SSM parameter encryption
     agentRole.addToPolicy(
       new PolicyStatement({
         sid: 'KMSDecrypt',


### PR DESCRIPTION
## Cost page

Adds COST.md: what a month of this stack actually costs (~$10-14, almost all of it model inference), from Cost Explorer data for May-July 2026. The doc carries its own disclaimer and pricing links.

## Doc and comment cleanup

Deleted inline comments that restate the code, collapsed docstrings that restated signatures, and cut CONTRIBUTING.md boilerplate duplicated in agent/README.md and DEPLOYMENT.md. Quality checks and CDK tests pass with snapshots unchanged.