### PR TITLE
Move agent instructions to AGENTS.md and enforce CDK imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,4 @@
 ## Conventions
 
 - **Env vars**: all in `agent/.env`, loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
-- **CDK imports**: explicit only, no wildcards, e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
 - **AgentCore regions**: not available everywhere; check the [AWS availability page](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) before deploying. CI deploys to us-west-2. Not enforced in code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Job Search Agent
+
+## Conventions
+
+- **Env vars**: all in `agent/.env`, loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
+- **CDK imports**: explicit only, no wildcards, e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
+- **AgentCore regions**: not available everywhere; check the [AWS availability page](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) before deploying. CI deploys to us-west-2. Not enforced in code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# Job Search Agent
-
-## Conventions
-
-- **Env vars**: all in `agent/.env`, loaded by the agent for local dev AND by CDK during deploy (`cdk/cdk.json` uses `--env-file-if-exists=../agent/.env`). There is no `cdk/.env`.
-- **CDK imports**: explicit only, no wildcards, e.g. `import { Stack } from "aws-cdk-lib"`, not `import * as cdk`.
-- **AgentCore regions**: not available everywhere; check the [AWS availability page](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) before deploying. CI deploys to us-west-2. Not enforced in code.
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ npm run cdk:deploy   # Deploy to AWS
 
 ## Code Standards
 
+Project conventions live in `AGENTS.md`.
+
 ### Python Code Style
 
 - **Line length**: 100 characters
@@ -108,7 +110,6 @@ npm run cdk:deploy   # Deploy to AWS
 - **Formatter**: Prettier
 - **Linter**: ESLint
 - **Testing**: Vitest with snapshot testing
-- **Imports**: Use explicit imports (`import { Stack } from 'aws-cdk-lib'`), never wildcards (`import * as cdk`)
 
 ## Project Structure
 

--- a/cdk/eslint.config.mjs
+++ b/cdk/eslint.config.mjs
@@ -16,6 +16,17 @@ export default [
     },
   },
   {
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'ImportDeclaration[source.value=/^aws-cdk-lib/] > ImportNamespaceSpecifier',
+          message: "Import CDK constructs explicitly, e.g. import { Stack } from 'aws-cdk-lib'.",
+        },
+      ],
+    },
+  },
+  {
     files: ['**/*.js', '**/*.mjs'],
     ...tseslint.configs.disableTypeChecked,
   },


### PR DESCRIPTION
`CLAUDE.md` is only read by Claude Code, so anyone using Codex, Cursor, Kiro, or Copilot got none of the project conventions. [AGENTS.md](https://agents.md/) is the open format those tools read.

Claude Code reads `CLAUDE.md` rather than `AGENTS.md`, so `CLAUDE.md` is now a one-line `@AGENTS.md` import. Used the import rather than a symlink because symlink creation on Windows needs Administrator or Developer Mode.

`AGENTS.md` owns conventions, `CONTRIBUTING.md` owns process.

The CDK wildcard-import rule was documented in two places and enforced nowhere. It moves to eslint, scoped to `aws-cdk-lib` so `import * as path from 'path'` keeps working.
